### PR TITLE
allow to use system brotli library

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,38 +1,83 @@
 dnl config.m4 for extension brotli
 
-dnl Check PHP version:
+dnl Check PHP version ID:
 AC_MSG_CHECKING(PHP version)
 if test ! -z "$phpincludedir"; then
-    PHP_VERSION=`grep 'PHP_VERSION ' $phpincludedir/main/php_version.h | sed -e 's/.*"\([[0-9\.]]*\)".*/\1/g' 2>/dev/null`
+    PHP_VERSION_ID=`grep 'PHP_VERSION_ID' $phpincludedir/main/php_version.h | sed -e 's/.* \([[0-9]]*\)/\1/g' 2>/dev/null`
 elif test ! -z "$PHP_CONFIG"; then
-    PHP_VERSION=`$PHP_CONFIG --version 2>/dev/null`
+    PHP_VERSION_ID=`$PHP_CONFIG --vernum 2>/dev/null`
 fi
 
-if test x"$PHP_VERSION" = "x"; then
+if test x"$PHP_VERSION_ID" = "x"; then
     AC_MSG_WARN([none])
 else
-    PHP_MAJOR_VERSION=`echo $PHP_VERSION | sed -e 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\1/g' 2>/dev/null`
-    PHP_MINOR_VERSION=`echo $PHP_VERSION | sed -e 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\2/g' 2>/dev/null`
-    PHP_RELEASE_VERSION=`echo $PHP_VERSION | sed -e 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\3/g' 2>/dev/null`
-    AC_MSG_RESULT([$PHP_VERSION])
+    AC_MSG_RESULT($PHP_VERSION_ID)
 fi
 
-if test $PHP_MAJOR_VERSION -lt 5; then
+if test $PHP_VERSION_ID -lt 50000; then
    AC_MSG_ERROR([need at least PHP 5 or newer])
 fi
 
 PHP_ARG_ENABLE(brotli, whether to enable brotli support,
 [  --enable-brotli         Enable brotli support])
 
+PHP_ARG_WITH(libbrotli, whether to use system brotli library,
+[  --with-libbrotli=DIR    Use libbrotli], no, no)
+
 if test "$PHP_BROTLI" != "no"; then
+
+  BROTLI_MIN_VERSION=0.6
+
+  if test "$PHP_LIBBROTLI" != "no"; then
+    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+
+    AC_MSG_CHECKING(for libbrotlienc)
+    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libbrotlienc; then
+      if $PKG_CONFIG libbrotlienc --atleast-version $BROTLI_MIN_VERSION; then
+        LIBBROTLIENC_CFLAGS=`$PKG_CONFIG libbrotlienc --cflags`
+        LIBBROTLIENC_LIBS=`$PKG_CONFIG libbrotlienc --libs`
+        LIBBROTLIENC_VERSION=`$PKG_CONFIG libbrotlienc --modversion`
+        AC_MSG_RESULT(from pkgconfig: version $LIBBROTLIENC_VERSION found)
+      else
+        AC_MSG_ERROR(system libbrotlienc must be upgraded to version >= $BROTLI_MIN_VERSION)
+      fi
+    else
+      AC_MSG_ERROR(system libbrotlienc not found)
+    fi
+    PHP_EVAL_INCLINE($LIBBROTLIENC_CFLAGS)
+    PHP_EVAL_LIBLINE($LIBBROTLIENC_LIBS, BROTLI_SHARED_LIBADD)
+
+    AC_MSG_CHECKING(for libbrotlidec)
+    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libbrotlidec; then
+      if $PKG_CONFIG libbrotlidec --atleast-version $BROTLI_MIN_VERSION; then
+        LIBBROTLIDEC_CFLAGS=`$PKG_CONFIG libbrotlidec --cflags`
+        LIBBROTLIDEC_LIBS=`$PKG_CONFIG libbrotlidec --libs`
+        LIBBROTLIDEC_VERSION=`$PKG_CONFIG libbrotlidec --modversion`
+        AC_MSG_RESULT(from pkgconfig: version $LIBBROTLIDEC_VERSION found)
+      else
+        AC_MSG_ERROR(system libbrotlienc must be upgraded to version >= $BROTLI_MIN_VERSION)
+      fi
+    else
+      AC_MSG_ERROR(system libbrotlienc not found)
+    fi
+    PHP_EVAL_INCLINE($LIBBROTLIDEC_CFLAGS)
+    PHP_EVAL_LIBLINE($LIBBROTLIDEC_LIBS, BROTLI_SHARED_LIBADD)
+    AC_DEFINE_UNQUOTED(BROTLI_LIB_VERSION, "$LIBBROTLIDEC_VERSION", [system library version])
+  else
+    AC_MSG_CHECKING(for brotli)
+    AC_MSG_RESULT(use bundled copy)
+    AC_DEFINE_UNQUOTED(BROTLI_LIB_VERSION, "1.0.1", [bundled library version])
 
     BROTLI_COMMON_SOURCES="brotli/c/common/dictionary.c"
     BROTLI_ENC_SOURCES="brotli/c/enc/backward_references.c brotli/c/enc/backward_references_hq.c brotli/c/enc/bit_cost.c brotli/c/enc/block_splitter.c brotli/c/enc/brotli_bit_stream.c brotli/c/enc/cluster.c brotli/c/enc/compress_fragment.c brotli/c/enc/compress_fragment_two_pass.c brotli/c/enc/dictionary_hash.c brotli/c/enc/encode.c brotli/c/enc/entropy_encode.c brotli/c/enc/histogram.c brotli/c/enc/literal_cost.c brotli/c/enc/memory.c brotli/c/enc/metablock.c brotli/c/enc/static_dict.c brotli/c/enc/utf8_util.c"
     BROTLI_DEC_SOURCES="brotli/c/dec/bit_reader.c brotli/c/dec/decode.c brotli/c/dec/huffman.c brotli/c/dec/state.c"
+  fi
 
-    PHP_SUBST(BROTLI_SHARED_LIBADD)
+  PHP_SUBST(BROTLI_SHARED_LIBADD)
 
-    PHP_NEW_EXTENSION(brotli, brotli.c $BROTLI_COMMON_SOURCES $BROTLI_ENC_SOURCES $BROTLI_DEC_SOURCES, $ext_shared)
+  PHP_NEW_EXTENSION(brotli, brotli.c $BROTLI_COMMON_SOURCES $BROTLI_ENC_SOURCES $BROTLI_DEC_SOURCES, $ext_shared)
 
+  if test -n "$BROTLI_COMMON_SOURCES" ; then
     PHP_ADD_INCLUDE([$ext_srcdir/brotli/c/include])
+  fi
 fi

--- a/php_brotli.h
+++ b/php_brotli.h
@@ -6,7 +6,6 @@ extern "C" {
 #endif
 
 #define BROTLI_EXT_VERSION "0.5.0"
-#define BROTLI_LIB_VERSION "1.0.1"
 
 extern zend_module_entry brotli_module_entry;
 #define phpext_brotli_ptr &brotli_module_entry


### PR DESCRIPTION
* config.m4 is broken for RC versions, so I switch to test PHP_VERSION_ID, which seems simpler

btw, perhaps this check can even be removed (PHP 4 still exists ?)

* building using `--with-libbrotli` will ignore the bundled library and use the system one.

Tested (build + tests) with broti version **0.6.0** ([available in Fedora](https://rpms.remirepo.net/rpmphp/zoom.php?rpm=brotli)) with **PHP 5.4.45, 5.5.38, 5.6.32, 7.0.25, 7.1.12RC1 and 7.2.0RC6**


Notice: using bundled library is usually forbidden in Linux distro (at least higly discouraged)


Bundled version is no more in php_brotly.h but instead in config.m4
`    AC_DEFINE_UNQUOTED(BROTLI_LIB_VERSION, "1.0.1", [bundled library version])`

Minimal supported version is also define in config.m4
`  BROTLI_MIN_VERSION=0.6`