### PR TITLE
Add env to skip online test

### DIFF
--- a/tests/streams_006.phpt
+++ b/tests/streams_006.phpt
@@ -3,6 +3,7 @@ compress.brotli read online stream denied
 --SKIPIF--
 <?php
 if (version_compare(PHP_VERSION, '5.4', '<')) die('skip PHP is too old');
+if (getenv("SKIP_ONLINE_TESTS")) die('skip online test');
 ?>
 --INI--
 allow_url_fopen=0


### PR DESCRIPTION
Same option as https://github.com/kjdev/php-ext-brotli/blob/master/tests/streams_005.phpt has.