### PR TITLE
Shim TSRMLS_* constants for PHP 8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - master
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 'master'
 
 env:
   - REPORT_EXIT_STATUS=1 NO_INTERACTION=1

--- a/brotli.c
+++ b/brotli.c
@@ -17,6 +17,16 @@
 #include "brotli/encode.h"
 #include "brotli/decode.h"
 
+#ifndef TSRMLS_C
+#define TSRMLS_C
+#endif
+#ifndef TSRMLS_CC
+#define TSRMLS_CC
+#endif
+#ifndef TSRMLS_DC
+#define TSRMLS_DC
+#endif
+
 ZEND_DECLARE_MODULE_GLOBALS(brotli);
 
 static ZEND_FUNCTION(brotli_compress);


### PR DESCRIPTION
Enable CI on PHP master (allow failure)