### PR TITLE
Add PHP 8.1 to build matrices

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - '8.1-alpine'
           - '8.0-alpine'
           - '8.0-zts-buster' # NOTE: error occurs with alpine
           - '7.4-alpine'

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - '8.1'
           - '8.0'
           - '7.4'
           - '7.3'
@@ -33,6 +34,8 @@ jobs:
           - vc: vc15
             os: windows-2016
         exclude:
+          - php: '8.1'
+            vc: vc15
           - php: '8.0'
             vc: vc15
           - php: '7.4'

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -30,7 +30,7 @@ jobs:
           - true
         include:
           - vc: vs16
-            os: windows-latest
+            os: windows-2019
           - vc: vc15
             os: windows-2016
         exclude:


### PR DESCRIPTION
* [x] Looks good for Linux: https://github.com/thekid/php-ext-brotli/actions/runs/1860972027
* [x] Works for Windows with `os: windows-2019`: https://github.com/thekid/php-ext-brotli/actions/runs/1861070305