### PR TITLE
Drop PHP 5 support

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -35,16 +35,6 @@ jobs:
             image: ghcr.io/kjdev/php
           - php: '7.0-alpine'
             image: ghcr.io/kjdev/php
-          - php: '5.6-buster' # NOTE: error occurs with alpine
-            image: ghcr.io/kjdev/php
-          - php: '5.5-buster' # NOTE: error occurs with alpine
-            image: ghcr.io/kjdev/php
-          - php: '5.4-buster' # NOTE: error occurs with alpine
-            image: ghcr.io/kjdev/php
-          - php: '5.3-alpine'
-            image: ghcr.io/kjdev/php
-          - php: '5.2-alpine'
-            image: ghcr.io/kjdev/php
 
     container:
       image: ${{ matrix.image }}:${{ matrix.php }}
@@ -64,8 +54,7 @@ jobs:
       - name: adding github workspace as safe directory
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Checkout repository
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@v4
       - name: Checkout submodules
         run: |
           git submodule update --init --recursive

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout submodule
         run: .\.github\workflows\submodule.ps1

--- a/brotli.c
+++ b/brotli.c
@@ -100,10 +100,6 @@ static const size_t PHP_BROTLI_BUFFER_SIZE = 1 << 19;
 static int php_brotli_encoder_create(BrotliEncoderState **encoder,
                                      long quality, int lgwin, long mode)
 {
-#if PHP_MAJOR_VERSION < 7
-    TSRMLS_FETCH();
-#endif
-
     *encoder = BrotliEncoderCreateInstance(NULL, NULL, NULL);
     if (!*encoder) {
         return FAILURE;
@@ -243,9 +239,6 @@ static int php_brotli_output_handler(void **handler_context,
 {
     long quality = BROTLI_DEFAULT_QUALITY;
     php_brotli_context *ctx = *(php_brotli_context **)handler_context;
-#if PHP_MAJOR_VERSION < 7
-    TSRMLS_FETCH();
-#endif
 
     if (!php_brotli_output_encoding()) {
         if ((output_context->op & PHP_OUTPUT_HANDLER_START)
@@ -387,9 +380,6 @@ php_brotli_output_handler_init(const char *handler_name,
                                size_t chunk_size, int flags)
 {
     php_output_handler *handler = NULL;
-#if PHP_MAJOR_VERSION < 7
-    TSRMLS_FETCH();
-#endif
 
     handler = php_output_handler_create_internal(handler_name, handler_name_len,
                                                  php_brotli_output_handler,
@@ -416,10 +406,6 @@ php_brotli_output_handler_init(const char *handler_name,
 
 static void php_brotli_cleanup_ob_handler_mess(void)
 {
-#if PHP_MAJOR_VERSION < 7
-    TSRMLS_FETCH();
-#endif
-
     if (BROTLI_G(ob_handler)) {
         php_brotli_output_handler_context_dtor(
             (void *) BROTLI_G(ob_handler) TSRMLS_CC
@@ -431,10 +417,6 @@ static void php_brotli_cleanup_ob_handler_mess(void)
 static void php_brotli_output_compression_start(void)
 {
     php_output_handler *h;
-#if PHP_MAJOR_VERSION < 7
-    TSRMLS_FETCH();
-#endif
-
     switch (BROTLI_G(output_compression)) {
         case 0:
             break;

--- a/brotli.c
+++ b/brotli.c
@@ -968,7 +968,7 @@ ZEND_MINIT_FUNCTION(brotli)
     php_register_url_stream_wrapper(STREAM_NAME,
                                     &php_stream_brotli_wrapper TSRMLS_CC);
 
-#if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
+#if defined(HAVE_APCU_SUPPORT)
     apc_register_serializer("brotli",
                             APC_SERIALIZER_NAME(brotli),
                             APC_UNSERIALIZER_NAME(brotli),
@@ -1022,13 +1022,13 @@ ZEND_MINFO_FUNCTION(brotli)
              version >> 24, (version >> 12) & 0xfff, version & 0xfff);
     php_info_print_table_row(2, "Library Version", buffer);
 #endif
-#if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
+#if defined(HAVE_APCU_SUPPORT)
     php_info_print_table_row(2, "APCu serializer ABI", APC_SERIALIZER_ABI);
 #endif
     php_info_print_table_end();
 }
 
-#if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
+#if defined(HAVE_APCU_SUPPORT)
 static const zend_module_dep brotli_module_deps[] = {
     ZEND_MOD_OPTIONAL("apcu")
     ZEND_MOD_END
@@ -1036,7 +1036,7 @@ static const zend_module_dep brotli_module_deps[] = {
 #endif
 
 zend_module_entry brotli_module_entry = {
-#if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
+#if defined(HAVE_APCU_SUPPORT)
     STANDARD_MODULE_HEADER_EX,
     NULL,
     brotli_module_deps,
@@ -1372,7 +1372,7 @@ static ZEND_FUNCTION(brotli_uncompress_add)
 }
 #endif
 
-#if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
+#if defined(HAVE_APCU_SUPPORT)
 static int APC_SERIALIZER_NAME(brotli)(APC_SERIALIZER_ARGS)
 {
     int result;

--- a/brotli.c
+++ b/brotli.c
@@ -6,12 +6,8 @@
 #include <SAPI.h>
 #include <php_ini.h>
 #include <ext/standard/info.h>
-#if ZEND_MODULE_API_NO >= 20141001
 #include <ext/standard/php_smart_string.h>
-#else
-#include <ext/standard/php_smart_str.h>
-#endif
-#if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
+#if defined(HAVE_APCU_SUPPORT)
 #include <ext/standard/php_var.h>
 #include <ext/apcu/apc_serializer.h>
 #include <zend_smart_str.h>
@@ -28,9 +24,7 @@
 #define TSRMLS_DC
 #endif
 
-#if PHP_VERSION_ID >= 70000
 int le_state;
-#endif
 
 # pragma GCC diagnostic ignored "-Wpointer-sign"
 
@@ -38,12 +32,10 @@ ZEND_DECLARE_MODULE_GLOBALS(brotli);
 
 static ZEND_FUNCTION(brotli_compress);
 static ZEND_FUNCTION(brotli_uncompress);
-#if PHP_VERSION_ID >= 70000
 static ZEND_FUNCTION(brotli_compress_init);
 static ZEND_FUNCTION(brotli_compress_add);
 static ZEND_FUNCTION(brotli_uncompress_init);
 static ZEND_FUNCTION(brotli_uncompress_add);
-#endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_compress, 0, 0, 1)
     ZEND_ARG_INFO(0, data)
@@ -56,7 +48,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_uncompress, 0, 0, 1)
     ZEND_ARG_INFO(0, max)
 ZEND_END_ARG_INFO()
 
-#if PHP_VERSION_ID >= 70000
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_compress_init, 0, 0, 0)
     ZEND_ARG_INFO(0, quality)
     ZEND_ARG_INFO(0, mode)
@@ -76,9 +67,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_uncompress_add, 0, 0, 2)
     ZEND_ARG_INFO(0, data)
     ZEND_ARG_INFO(0, mode)
 ZEND_END_ARG_INFO()
-#endif
 
-#if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
+#if defined(HAVE_APCU_SUPPORT)
 static int APC_SERIALIZER_NAME(brotli)(APC_SERIALIZER_ARGS);
 static int APC_UNSERIALIZER_NAME(brotli)(APC_UNSERIALIZER_ARGS);
 #endif
@@ -86,13 +76,10 @@ static int APC_UNSERIALIZER_NAME(brotli)(APC_UNSERIALIZER_ARGS);
 static zend_function_entry brotli_functions[] = {
     ZEND_FE(brotli_compress, arginfo_brotli_compress)
     ZEND_FE(brotli_uncompress, arginfo_brotli_uncompress)
-#if PHP_VERSION_ID > 50300 // PHP 5.3+
     ZEND_NS_FALIAS(BROTLI_NS, compress,
                    brotli_compress, arginfo_brotli_compress)
     ZEND_NS_FALIAS(BROTLI_NS, uncompress,
                    brotli_uncompress, arginfo_brotli_uncompress)
-#endif
-#if PHP_VERSION_ID >= 70000
     ZEND_FE(brotli_compress_init, arginfo_brotli_compress_init)
     ZEND_FE(brotli_compress_add, arginfo_brotli_compress_add)
     ZEND_FE(brotli_uncompress_init, arginfo_brotli_uncompress_init)
@@ -105,7 +92,6 @@ static zend_function_entry brotli_functions[] = {
                    brotli_uncompress_init, arginfo_brotli_uncompress_init)
     ZEND_NS_FALIAS(BROTLI_NS, uncompress_add,
                    brotli_uncompress_add, arginfo_brotli_uncompress_add)
-#endif
     ZEND_FE_END
 };
 

--- a/php_brotli.h
+++ b/php_brotli.h
@@ -16,11 +16,6 @@ extern "C" {
 extern zend_module_entry brotli_module_entry;
 #define phpext_brotli_ptr &brotli_module_entry
 
-/* support php-5.2m backport from php-5.3 */
-#ifndef ZEND_FE_END
-#define ZEND_FE_END            { NULL, NULL, NULL, 0, 0 }
-#endif
-
 #ifdef PHP_WIN32
 #    define PHP_BROTLI_API __declspec(dllexport)
 #elif defined(__GNUC__) && __GNUC__ >= 4
@@ -31,10 +26,6 @@ extern zend_module_entry brotli_module_entry;
 
 #ifdef ZTS
 #    include "TSRM.h"
-#endif
-
-#if PHP_MAJOR_VERSION < 7
-typedef long zend_long;
 #endif
 
 typedef struct _php_brotli_state_context {
@@ -52,13 +43,11 @@ typedef struct _php_brotli_context {
 } php_brotli_context;
 
 ZEND_BEGIN_MODULE_GLOBALS(brotli)
-#if PHP_VERSION_ID > 50400 // Output Handler: 5.4+
   zend_long output_compression;
   zend_long output_compression_level;
   zend_bool handler_registered;
   int compression_coding;
   php_brotli_context *ob_handler;
-#endif
 ZEND_END_MODULE_GLOBALS(brotli)
 
 #ifdef ZTS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows for better performance.
- **Refactor**
	- Improved support and compatibility with newer PHP versions by removing outdated version conditionals and updating code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->