### PR TITLE
Use fast param parser API

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ brotli.output\_compression\_level | -1      | PHP\_INI\_ALL
     Specify a value between 0 to 11.
     The default value of -1 uses internally defined values (11).
 
-> Available since PHP 5.4.0.
-
 ## Constant
 
 Name                              | Description
@@ -74,10 +72,10 @@ BROTLI\_COMPRESS\_LEVEL\_DEFAULT  | Default compress level value
 
 * brotli\_compress — Compress a string
 * brotli\_uncompress — Uncompress a compressed string
-* brotli\_compress\_init — Initialize an incremental compress context (PHP 7)
-* brotli\_compress\_add — Incrementally compress data (PHP 7)
-* brotli\_uncompress\_init — Initialize an incremental uncompress context (PHP 7)
-* brotli\_uncompress\_add — Incrementally uncompress data (PHP 7)
+* brotli\_compress\_init — Initialize an incremental compress context
+* brotli\_compress\_add — Incrementally compress data
+* brotli\_uncompress\_init — Initialize an incremental uncompress context
+* brotli\_uncompress\_add — Incrementally uncompress data
 
 ---
 ### brotli\_compress — Compress a string
@@ -138,7 +136,7 @@ The original uncompressed data or FALSE on error.
 
 resource **brotli\_compress\_init** ( [ int _$quality_ = BROTLI\_COMPRESS\_LEVEL\_DEFAULT, int _$mode_ = BROTLI\_GENERIC ] )
 
-Initialize an incremental compress context. (PHP 7)
+Initialize an incremental compress context.
 
 #### Parameters
 
@@ -164,7 +162,7 @@ or FALSE on failure.
 
 string **brotli\_compress\_add** ( resource _$context_, string _$data_ [, _$mode_ = BROTLI\_FLUSH ] )
 
-Incrementally compress data. (PHP 7)
+Incrementally compress data.
 
 #### Parameters
 
@@ -193,7 +191,7 @@ Returns a chunk of compressed data, or FALSE on failure.
 
 resource **brotli\_uncompress\_init** ( void )
 
-Initialize an incremental uncompress context. (PHP 7)
+Initialize an incremental uncompress context.
 
 #### Return Values
 
@@ -207,7 +205,7 @@ or FALSE on failure.
 
 string **brotli\_uncompress\_add** ( resource _$context_, string _$data_ [, _$mode_ = BROTLI\_FLUSH ] )
 
-Incrementally uncompress data. (PHP 7)
+Incrementally uncompress data.
 
 #### Parameters
 

--- a/brotli.c
+++ b/brotli.c
@@ -636,7 +636,7 @@ static int php_brotli_compress_close(php_stream *stream,
             }
         } else {
             php_error_docref(NULL, E_WARNING,
-                             "brotli compress error\n");
+                             "brotli compress error");
         }
     }
 
@@ -698,7 +698,7 @@ static ssize_t php_brotli_compress_write(php_stream *stream,
                 php_stream_write(self->stream, output, out_size);
             }
         } else {
-            php_error_docref(NULL, E_WARNING, "brotli compress error\n");
+            php_error_docref(NULL, E_WARNING, "brotli compress error");
 #if PHP_VERSION_ID >= 70400
             return -1;
 #endif
@@ -1015,7 +1015,7 @@ static ZEND_FUNCTION(brotli_compress)
                                in_size, (const uint8_t*)in,
                                &out_size, (uint8_t*)out)) {
         php_error_docref(NULL, E_WARNING,
-                         "Brotli compress failed\n");
+                         "Brotli compress failed");
         efree(out);
         RETURN_FALSE;
     }
@@ -1041,7 +1041,7 @@ static ZEND_FUNCTION(brotli_compress_init)
     if (php_brotli_encoder_create(&ctx->encoder,
                                   quality, 0, mode) != SUCCESS) {
         php_error_docref(NULL, E_WARNING,
-                         "Brotli incremental compress init failed\n");
+                         "Brotli incremental compress init failed");
         RETURN_FALSE;
     }
 
@@ -1068,7 +1068,7 @@ static ZEND_FUNCTION(brotli_compress_add)
     ctx = zend_fetch_resource(Z_RES_P(res), NULL, le_state);
     if (ctx == NULL || ctx->encoder == NULL) {
         php_error_docref(NULL, E_WARNING,
-                         "Brotli incremental compress resource failed\n");
+                         "Brotli incremental compress resource failed");
         RETURN_FALSE;
     }
 
@@ -1097,7 +1097,7 @@ static ZEND_FUNCTION(brotli_compress_add)
             efree(buffer);
             smart_string_free(&out);
             php_error_docref(NULL, E_WARNING,
-                             "Brotli incremental compress failed\n");
+                             "Brotli incremental compress failed");
             RETURN_FALSE;
         }
     }
@@ -1121,7 +1121,7 @@ static ZEND_FUNCTION(brotli_compress_add)
                 efree(buffer);
                 smart_string_free(&out);
                 php_error_docref(NULL, E_WARNING,
-                                 "Brotli incremental compress failed\n");
+                                 "Brotli incremental compress failed");
                 RETURN_FALSE;
             }
         }
@@ -1153,7 +1153,7 @@ static ZEND_FUNCTION(brotli_uncompress)
     BrotliDecoderState *state = BrotliDecoderCreateInstance(NULL, NULL, NULL);
     if (!state) {
         php_error_docref(NULL, E_WARNING,
-                         "Invalid Brotli state\n");
+                         "Invalid Brotli state");
         RETURN_FALSE;
     }
 
@@ -1180,7 +1180,7 @@ static ZEND_FUNCTION(brotli_uncompress)
 
     if (result != BROTLI_DECODER_RESULT_SUCCESS) {
         php_error_docref(NULL, E_WARNING,
-                         "Brotli decompress failed\n");
+                         "Brotli decompress failed");
         smart_string_free(&out);
         RETURN_FALSE;
     }
@@ -1201,7 +1201,7 @@ static ZEND_FUNCTION(brotli_uncompress_init)
 
     if (php_brotli_decoder_create(&ctx->decoder) != SUCCESS) {
         php_error_docref(NULL, E_WARNING,
-                         "Brotli incremental uncompress init failed\n");
+                         "Brotli incremental uncompress init failed");
         RETURN_FALSE;
     }
 
@@ -1228,7 +1228,7 @@ static ZEND_FUNCTION(brotli_uncompress_add)
     ctx = zend_fetch_resource(Z_RES_P(res), NULL, le_state);
     if (ctx == NULL || ctx->decoder == NULL) {
         php_error_docref(NULL, E_WARNING,
-                         "Brotli incremental uncompress resource failed\n");
+                         "Brotli incremental uncompress resource failed");
         RETURN_FALSE;
     }
 

--- a/brotli.c
+++ b/brotli.c
@@ -989,11 +989,12 @@ static ZEND_FUNCTION(brotli_compress)
     long quality = BROTLI_DEFAULT_QUALITY;
     long mode =  BROTLI_MODE_GENERIC;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(),
-                              "s|ll", &in, &in_size,
-                              &quality, &mode) == FAILURE) {
-        RETURN_FALSE;
-    }
+    ZEND_PARSE_PARAMETERS_START(1, 3)
+        Z_PARAM_STRING(in, in_size)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(quality)
+        Z_PARAM_LONG(mode)
+    ZEND_PARSE_PARAMETERS_END();
 
     size_t out_size = BrotliEncoderMaxCompressedSize(in_size);
     char *out = (char *)emalloc(out_size);
@@ -1029,10 +1030,11 @@ static ZEND_FUNCTION(brotli_compress_init)
     long mode =  BROTLI_MODE_GENERIC;
     php_brotli_state_context *ctx;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(),
-                              "|ll", &quality, &mode) == FAILURE) {
-        RETURN_FALSE;
-    }
+    ZEND_PARSE_PARAMETERS_START(0, 2)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(quality)
+        Z_PARAM_LONG(mode)
+    ZEND_PARSE_PARAMETERS_END();
 
     ctx = php_brotli_state_init();
 
@@ -1056,10 +1058,12 @@ static ZEND_FUNCTION(brotli_compress_add)
     size_t in_size;
     smart_string out = {0};
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs|l",
-                              &res, &in_buf, &in_size, &mode) != SUCCESS) {
-        RETURN_FALSE;
-    }
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_RESOURCE(res)
+        Z_PARAM_STRING(in_buf, in_size)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(mode)
+    ZEND_PARSE_PARAMETERS_END();
 
     ctx = zend_fetch_resource(Z_RES_P(res), NULL, le_state);
     if (ctx == NULL || ctx->encoder == NULL) {
@@ -1136,10 +1140,11 @@ static ZEND_FUNCTION(brotli_uncompress)
     size_t in_size;
     smart_string out = {0};
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l",
-                              &in, &in_size, &max_size) == FAILURE) {
-        RETURN_FALSE;
-    }
+    ZEND_PARSE_PARAMETERS_START(1, 2)
+        Z_PARAM_STRING(in, in_size)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(max_size)
+    ZEND_PARSE_PARAMETERS_END();
 
     if (max_size && max_size < in_size) {
         in_size = max_size;
@@ -1213,10 +1218,12 @@ static ZEND_FUNCTION(brotli_uncompress_add)
     size_t in_size;
     smart_string out = {0};
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs|l",
-                              &res, &in_buf, &in_size, &mode) != SUCCESS) {
-        RETURN_FALSE;
-    }
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_RESOURCE(res)
+        Z_PARAM_STRING(in_buf, in_size)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(mode)
+    ZEND_PARSE_PARAMETERS_END();
 
     ctx = zend_fetch_resource(Z_RES_P(res), NULL, le_state);
     if (ctx == NULL || ctx->decoder == NULL) {

--- a/config.m4
+++ b/config.m4
@@ -14,8 +14,8 @@ else
     AC_MSG_RESULT($PHP_VERSION_ID)
 fi
 
-if test $PHP_VERSION_ID -lt 50000; then
-   AC_MSG_ERROR([need at least PHP 5 or newer])
+if test $PHP_VERSION_ID -lt 70000; then
+   AC_MSG_ERROR([need at least PHP 7 or newer])
 fi
 
 PHP_ARG_ENABLE(brotli, whether to enable brotli support,


### PR DESCRIPTION
Fast param parser API is supported since PHP7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved parameter parsing in compression functions for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->