### PR TITLE
Refactor/correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ BROTLI\_COMPRESS\_LEVEL\_DEFAULT  | Default compress level value
 
 #### Description
 
-string **brotli\_compress** ( string _$data_ [, int _$quality_ = BROTLI\_COMPRESS\_LEVEL\_DEFAULT, int _$mode_ = BROTLI\_GENERIC ] )
+string **brotli\_compress** ( string _$data_ [, int _$level_ = BROTLI\_COMPRESS\_LEVEL\_DEFAULT, int _$mode_ = BROTLI\_GENERIC ] )
 
 This function compress a string.
 
@@ -92,9 +92,9 @@ This function compress a string.
 
   The data to compress.
 
-* _quality_
+* _level_
 
-  The higher the quality, the slower the compression.
+  The higher the level, the slower the compression.
   (Defaults to `BROTLI\_COMPRESS\_LEVEL\_DEFAULT`)
 
 * _mode_
@@ -134,15 +134,15 @@ The original uncompressed data or FALSE on error.
 
 #### Description
 
-Brotli\Compress\Context **brotli\_compress\_init** ( [ int _$quality_ = BROTLI\_COMPRESS\_LEVEL\_DEFAULT, int _$mode_ = BROTLI\_GENERIC ] )
+Brotli\Compress\Context **brotli\_compress\_init** ( [ int _$level_ = BROTLI\_COMPRESS\_LEVEL\_DEFAULT, int _$mode_ = BROTLI\_GENERIC ] )
 
 Initialize an incremental compress context.
 
 #### Parameters
 
-* _quality_
+* _level_
 
-  The higher the quality, the slower the compression.
+  The higher the level, the slower the compression.
   (Defaults to `BROTLI\_COMPRESS\_LEVEL\_DEFAULT`)
 
 * _mode_
@@ -232,9 +232,9 @@ Returns a chunk of uncompressed data, or FALSE on failure.
 ```
 Namespace Brotli;
 
-function compress( $data [, $quality = \\BROTLI\_COMPRESS\_LEVEL\_DEFAULT, $mode = \\BROTLI\_GENERIC ] )
+function compress( $data [, $level = \\BROTLI\_COMPRESS\_LEVEL\_DEFAULT, $mode = \\BROTLI\_GENERIC ] )
 function uncompress( $data [, $length = 0 ] )
-function compress\_init( [ $quality = \\BROTLI\_COMPRESS\_LEVEL\_DEFAULT, $mode = \\BROTLI\_GENERIC ] )
+function compress\_init( [ $level = \\BROTLI\_COMPRESS\_LEVEL\_DEFAULT, $mode = \\BROTLI\_GENERIC ] )
 function compress\_add( \\Brotli\\Compress\\Context $context, string $data [, $mode = \\BROTLI\_FLUSH] )
 function uncompress\_init()
 function uncompress\_add( \\Brotli\\UnCompress\\Context $context, string $data [, $mode = \\BROTLI\_FLUSH] )

--- a/brotli.c
+++ b/brotli.c
@@ -1369,6 +1369,8 @@ static ZEND_FUNCTION(brotli_uncompress)
         RETURN_FALSE;
     }
 
+    BrotliDecoderSetParameter(state, BROTLI_DECODER_PARAM_LARGE_WINDOW, 1u);
+
     size_t available_in = in_size;
     const uint8_t *next_in = (const uint8_t *)in;
     size_t buffer_size = PHP_BROTLI_BUFFER_SIZE;

--- a/brotli.c
+++ b/brotli.c
@@ -28,7 +28,7 @@ static ZEND_FUNCTION(brotli_uncompress_add);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_compress, 0, 0, 1)
     ZEND_ARG_INFO(0, data)
-    ZEND_ARG_INFO(0, quality)
+    ZEND_ARG_INFO(0, level)
     ZEND_ARG_INFO(0, mode)
 ZEND_END_ARG_INFO()
 
@@ -38,7 +38,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_uncompress, 0, 0, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_compress_init, 0, 0, 0)
-    ZEND_ARG_INFO(0, quality)
+    ZEND_ARG_INFO(0, level)
     ZEND_ARG_INFO(0, mode)
 ZEND_END_ARG_INFO()
 
@@ -1162,19 +1162,19 @@ static ZEND_FUNCTION(brotli_compress)
     char *in;
     size_t in_size;
 
-    zend_long quality = BROTLI_DEFAULT_QUALITY;
+    zend_long level = BROTLI_DEFAULT_QUALITY;
     zend_long mode =  BROTLI_MODE_GENERIC;
 
     ZEND_PARSE_PARAMETERS_START(1, 3)
         Z_PARAM_STRING(in, in_size)
         Z_PARAM_OPTIONAL
-        Z_PARAM_LONG(quality)
+        Z_PARAM_LONG(level)
         Z_PARAM_LONG(mode)
     ZEND_PARSE_PARAMETERS_END();
 
     php_brotli_context ctx;
     php_brotli_context_init(&ctx);
-    if (php_brotli_context_create_encoder_ex(&ctx, quality, 0, mode,
+    if (php_brotli_context_create_encoder_ex(&ctx, level, 0, mode,
                                              1) != SUCCESS) {
         php_brotli_context_close(&ctx);
         RETURN_FALSE;
@@ -1218,18 +1218,18 @@ static ZEND_FUNCTION(brotli_compress)
 
 static ZEND_FUNCTION(brotli_compress_init)
 {
-    zend_long quality = BROTLI_DEFAULT_QUALITY;
+    zend_long level = BROTLI_DEFAULT_QUALITY;
     zend_long mode =  BROTLI_MODE_GENERIC;
 
     ZEND_PARSE_PARAMETERS_START(0, 2)
         Z_PARAM_OPTIONAL
-        Z_PARAM_LONG(quality)
+        Z_PARAM_LONG(level)
         Z_PARAM_LONG(mode)
     ZEND_PARSE_PARAMETERS_END();
 
     PHP_BROTLI_CONTEXT_OBJ_INIT_OF_CLASS(php_brotli_compress_context_ce);
 
-    if (php_brotli_context_create_encoder_ex(ctx, quality, 0, mode,
+    if (php_brotli_context_create_encoder_ex(ctx, level, 0, mode,
                                              1) != SUCCESS) {
         zval_ptr_dtor(return_value);
         RETURN_FALSE;

--- a/brotli.c
+++ b/brotli.c
@@ -13,7 +13,13 @@
 #include <zend_smart_str.h>
 #endif
 #include <Zend/zend_interfaces.h>
+#if defined(USE_BROTLI_BUNDLED)
+# pragma GCC visibility push(hidden)
+#endif
 #include "php_brotli.h"
+#if defined(USE_BROTLI_BUNDLED)
+# pragma GCC visibility pop
+#endif
 
 # pragma GCC diagnostic ignored "-Wpointer-sign"
 

--- a/brotli.c
+++ b/brotli.c
@@ -34,7 +34,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_uncompress, 0, 0, 1)
     ZEND_ARG_INFO(0, data)
-    ZEND_ARG_INFO(0, max)
+    ZEND_ARG_INFO(0, length)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_compress_init, 0, 0, 0)

--- a/brotli.c
+++ b/brotli.c
@@ -1112,7 +1112,7 @@ ZEND_MINFO_FUNCTION(brotli)
 #ifdef BROTLI_LIB_VERSION
     php_info_print_table_row(2, "Library Version", BROTLI_LIB_VERSION);
 #else
-    uint32_t version = BrotliEncoderVersion();
+    uint32_t version = BrotliDecoderVersion();
     char buffer[64];
     snprintf(buffer, sizeof(buffer), "%d.%d.%d",
              version >> 24, (version >> 12) & 0xfff, version & 0xfff);

--- a/brotli.stub.php
+++ b/brotli.stub.php
@@ -57,11 +57,11 @@ namespace {
   const BROTLI_FINISH = UNKNOWN;
 
 
-  function brotli_compress(string $data, int $quality = BROTLI_COMPRESS_LEVEL_DEFAULT, int $mode = BROTLI_GENERIC): string|false {}
+  function brotli_compress(string $data, int $level = BROTLI_COMPRESS_LEVEL_DEFAULT, int $mode = BROTLI_GENERIC): string|false {}
 
   function brotli_uncompress(string $data, int $length = 0): string|false {}
 
-  function brotli_compress_init(int $quality = BROTLI_COMPRESS_LEVEL_DEFAULT, int $mode = BROTLI_GENERIC): Brotli\Compress\Context|false {}
+  function brotli_compress_init(int $level = BROTLI_COMPRESS_LEVEL_DEFAULT, int $mode = BROTLI_GENERIC): Brotli\Compress\Context|false {}
 
   function brotli_compress_add(Brotli\Compress\Context $context, string $data, int $mode = BROTLI_FLUSH): string|false {}
 
@@ -72,11 +72,11 @@ namespace {
 
 namespace Brotli {
 
-  function compress(string $data, int $quality = \BROTLI_COMPRESS_LEVEL_DEFAULT, int $mode = \BROTLI_GENERIC): string|false {}
+  function compress(string $data, int $level = \BROTLI_COMPRESS_LEVEL_DEFAULT, int $mode = \BROTLI_GENERIC): string|false {}
 
   function uncompress(string $data, int $length = 0): string|false {}
 
-  function compress_init(int $quality = \BROTLI_COMPRESS_LEVEL_DEFAULT, int $mode = \BROTLI_GENERIC): Compress\Context|false {}
+  function compress_init(int $level = \BROTLI_COMPRESS_LEVEL_DEFAULT, int $mode = \BROTLI_GENERIC): Compress\Context|false {}
 
   function compress_add(Compress\Context $context, string $data, int $mode = \BROTLI_FLUSH): string|false {}
 

--- a/config.m4
+++ b/config.m4
@@ -104,6 +104,8 @@ if test "$PHP_BROTLI" != "no"; then
       brotli/c/dec/huffman.c
       brotli/c/dec/state.c
     "
+
+    AC_DEFINE(USE_BROTLI_BUNDLED, 1, [use bundled])
   fi
 
   PHP_SUBST(BROTLI_SHARED_LIBADD)

--- a/config.w32
+++ b/config.w32
@@ -13,6 +13,8 @@ if (PHP_BROTLI != "no") {
     ADD_SOURCES("brotli/c/dec", "bit_reader.c decode.c huffman.c state.c", "brotli");
 
     ADD_FLAG("CFLAGS_BROTLI", " /I" + configure_module_dirname + " /I" + configure_module_dirname + "/brotli/c/include");
+
+    AC_DEFINE('USE_BROTLI_BUNDLED', 1, 'use bundled');
   }
   AC_DEFINE('BROTLI_MIN_VERSION', '0.6', 'libbrotlienc minimum version');
   PHP_INSTALL_HEADERS("ext/brotli/", "php_brotli.h");

--- a/tests/compatibility.phpt
+++ b/tests/compatibility.phpt
@@ -20,10 +20,10 @@ foreach ($files as $filename) {
 
     $split =  explode('.compressed', $filename);
     $expected = $split[0];
-    $quality = -1;
+    $level = -1;
 
     if (isset($split[1])) {
-        $quality = (int)$split[1];
+        $level = (int)$split[1];
     }
 
     if (file_exists($expected)) {
@@ -38,7 +38,7 @@ foreach ($files as $filename) {
             echo "  read uncompressed .. OK\n";
         }
 
-        $expected_data = brotli_compress($data, $quality);
+        $expected_data = brotli_compress($data, $level);
         if (!$expected_data) {
             echo "  compressed        .. NG\n";
             exit(1);

--- a/tests/compress_args.phpt
+++ b/tests/compress_args.phpt
@@ -4,10 +4,10 @@ brotli_compress() functionality with arguments
 <?php
 include(dirname(__FILE__) . '/data.inc');
 
-function test($data, $quality = 0, $mode = 0) {
-    echo "quality={$quality}, mode={$mode}\n";
+function test($data, $level = 0, $mode = 0) {
+    echo "level={$level}, mode={$mode}\n";
 
-    $compressed = brotli_compress($data, $quality, $mode);
+    $compressed = brotli_compress($data, $level, $mode);
     if ($compressed === false) {
         echo "ERROR\n";
         return;
@@ -20,8 +20,8 @@ function test($data, $quality = 0, $mode = 0) {
     }
 }
 
-foreach ([0, 9, 11, 20, -1] as $quality) {
-    test($data, $quality, BROTLI_GENERIC);
+foreach ([0, 9, 11, 20, -1] as $level) {
+    test($data, $level, BROTLI_GENERIC);
 }
 foreach ([0, 1, 2, 3, -1] as $mode) {
     test($data, BROTLI_COMPRESS_LEVEL_DEFAULT, $mode);
@@ -29,31 +29,31 @@ foreach ([0, 1, 2, 3, -1] as $mode) {
 ?>
 ===DONE===
 --EXPECTF--
-quality=0, mode=0
+level=0, mode=0
 OK
-quality=9, mode=0
+level=9, mode=0
 OK
-quality=11, mode=0
+level=11, mode=0
 OK
-quality=20, mode=0
+level=20, mode=0
 
-Warning: brotli_compress(): failed to compression quality (20): must be within 0..11 in %s on line %d
+Warning: brotli_compress(): failed to compression level (20): must be within 0..11 in %s on line %d
 ERROR
-quality=-1, mode=0
+level=-1, mode=0
 
-Warning: brotli_compress(): failed to compression quality (-1): must be within 0..11 in %s on line %d
+Warning: brotli_compress(): failed to compression level (-1): must be within 0..11 in %s on line %d
 ERROR
-quality=11, mode=0
+level=11, mode=0
 OK
-quality=11, mode=1
+level=11, mode=1
 OK
-quality=11, mode=2
+level=11, mode=2
 OK
-quality=11, mode=3
+level=11, mode=3
 
 Warning: brotli_compress(): failed to compression mode (3): must be BROTLI_GENERIC(0)|BROTLI_TEXT(1)|BROTLI_FONT(2) in %s on line %d
 ERROR
-quality=11, mode=-1
+level=11, mode=-1
 
 Warning: brotli_compress(): failed to compression mode (-1): must be BROTLI_GENERIC(0)|BROTLI_TEXT(1)|BROTLI_FONT(2) in %s on line %d
 ERROR

--- a/tests/incremental_compress_add_args.phpt
+++ b/tests/incremental_compress_add_args.phpt
@@ -6,8 +6,8 @@ if (!extension_loaded('brotli')) die('skip need ext/brotli');
 ?>
 --FILE--
 <?php
-function test($quality = 0, $mode = 0, $types = []) {
-  echo "quality={$quality}, mode={$mode}\n";
+function test($level = 0, $mode = 0, $types = []) {
+  echo "level={$level}, mode={$mode}\n";
 
   $modeTypes = array_merge([
     'BROTLI_PROCESS' => BROTLI_PROCESS,
@@ -18,7 +18,7 @@ function test($quality = 0, $mode = 0, $types = []) {
 
     $uncompressed = $compressed = '';
 
-    $resource = brotli_compress_init($quality, $mode);
+    $resource = brotli_compress_init($level, $mode);
     if ($resource === false) {
       echo "ERROR\n";
       return;
@@ -42,8 +42,8 @@ function test($quality = 0, $mode = 0, $types = []) {
   }
 }
 
-foreach ([0, 9, 11, 20, -1] as $quality) {
-  test($quality, 0);
+foreach ([0, 9, 11, 20, -1] as $level) {
+  test($level, 0);
 }
 foreach ([0, 1, 2, 3, -1] as $mode) {
   test(0, $mode);
@@ -52,41 +52,41 @@ test(0, 0, ['INCORRECT' => -1]);
 ?>
 ===DONE===
 --EXPECTF--
-quality=0, mode=0
+level=0, mode=0
 OK
 OK
-quality=9, mode=0
+level=9, mode=0
 OK
 OK
-quality=11, mode=0
+level=11, mode=0
 OK
 OK
-quality=20, mode=0
+level=20, mode=0
 
-Warning: brotli_compress_init(): failed to compression quality (20): must be within 0..11 in %s on line %d
+Warning: brotli_compress_init(): failed to compression level (20): must be within 0..11 in %s on line %d
 ERROR
-quality=-1, mode=0
+level=-1, mode=0
 
-Warning: brotli_compress_init(): failed to compression quality (-1): must be within 0..11 in %s on line %d
+Warning: brotli_compress_init(): failed to compression level (-1): must be within 0..11 in %s on line %d
 ERROR
-quality=0, mode=0
+level=0, mode=0
 OK
 OK
-quality=0, mode=1
+level=0, mode=1
 OK
 OK
-quality=0, mode=2
+level=0, mode=2
 OK
 OK
-quality=0, mode=3
+level=0, mode=3
 
 Warning: brotli_compress_init(): failed to compression mode (3): must be BROTLI_GENERIC(0)|BROTLI_TEXT(1)|BROTLI_FONT(2) in %s on line %d
 ERROR
-quality=0, mode=-1
+level=0, mode=-1
 
 Warning: brotli_compress_init(): failed to compression mode (-1): must be BROTLI_GENERIC(0)|BROTLI_TEXT(1)|BROTLI_FONT(2) in %s on line %d
 ERROR
-quality=0, mode=0
+level=0, mode=0
 OK
 OK
 

--- a/tests/roundtrip.phpt
+++ b/tests/roundtrip.phpt
@@ -18,14 +18,14 @@ $files = roundtrip_files();
 $qualities = array(BROTLI_COMPRESS_LEVEL_MIN, 6, 9, BROTLI_COMPRESS_LEVEL_MAX);
 
 foreach ($files as $filename) {
-    foreach ($qualities as $quality) {
-        echo 'Roundtrip testing file ', basename($filename), ' at quality ', $quality, PHP_EOL;
+    foreach ($qualities as $level) {
+        echo 'Roundtrip testing file ', basename($filename), ' at level ', $level, PHP_EOL;
 
         $expected = $filename;
 
         if (file_exists($expected)) {
             $data = file_get_contents($expected);
-            $expected_data = brotli_uncompress(brotli_compress($data, $quality));
+            $expected_data = brotli_uncompress(brotli_compress($data, $level));
             if ($data !== $expected_data) {
                 echo "  NG\n";
                 exit(1);
@@ -37,59 +37,59 @@ foreach ($files as $filename) {
 }
 
 --EXPECTF--
-Roundtrip testing file alice29.txt at quality 0
+Roundtrip testing file alice29.txt at level 0
   OK
-Roundtrip testing file alice29.txt at quality 6
+Roundtrip testing file alice29.txt at level 6
   OK
-Roundtrip testing file alice29.txt at quality 9
+Roundtrip testing file alice29.txt at level 9
   OK
-Roundtrip testing file alice29.txt at quality 11
+Roundtrip testing file alice29.txt at level 11
   OK
-Roundtrip testing file asyoulik.txt at quality 0
+Roundtrip testing file asyoulik.txt at level 0
   OK
-Roundtrip testing file asyoulik.txt at quality 6
+Roundtrip testing file asyoulik.txt at level 6
   OK
-Roundtrip testing file asyoulik.txt at quality 9
+Roundtrip testing file asyoulik.txt at level 9
   OK
-Roundtrip testing file asyoulik.txt at quality 11
+Roundtrip testing file asyoulik.txt at level 11
   OK
-Roundtrip testing file lcet10.txt at quality 0
+Roundtrip testing file lcet10.txt at level 0
   OK
-Roundtrip testing file lcet10.txt at quality 6
+Roundtrip testing file lcet10.txt at level 6
   OK
-Roundtrip testing file lcet10.txt at quality 9
+Roundtrip testing file lcet10.txt at level 9
   OK
-Roundtrip testing file lcet10.txt at quality 11
+Roundtrip testing file lcet10.txt at level 11
   OK
-Roundtrip testing file plrabn12.txt at quality 0
+Roundtrip testing file plrabn12.txt at level 0
   OK
-Roundtrip testing file plrabn12.txt at quality 6
+Roundtrip testing file plrabn12.txt at level 6
   OK
-Roundtrip testing file plrabn12.txt at quality 9
+Roundtrip testing file plrabn12.txt at level 9
   OK
-Roundtrip testing file plrabn12.txt at quality 11
+Roundtrip testing file plrabn12.txt at level 11
   OK
-Roundtrip testing file encode.c at quality 0
+Roundtrip testing file encode.c at level 0
   OK
-Roundtrip testing file encode.c at quality 6
+Roundtrip testing file encode.c at level 6
   OK
-Roundtrip testing file encode.c at quality 9
+Roundtrip testing file encode.c at level 9
   OK
-Roundtrip testing file encode.c at quality 11
+Roundtrip testing file encode.c at level 11
   OK
-Roundtrip testing file dictionary.h at quality 0
+Roundtrip testing file dictionary.h at level 0
   OK
-Roundtrip testing file dictionary.h at quality 6
+Roundtrip testing file dictionary.h at level 6
   OK
-Roundtrip testing file dictionary.h at quality 9
+Roundtrip testing file dictionary.h at level 9
   OK
-Roundtrip testing file dictionary.h at quality 11
+Roundtrip testing file dictionary.h at level 11
   OK
-Roundtrip testing file decode.c at quality 0
+Roundtrip testing file decode.c at level 0
   OK
-Roundtrip testing file decode.c at quality 6
+Roundtrip testing file decode.c at level 6
   OK
-Roundtrip testing file decode.c at quality 9
+Roundtrip testing file decode.c at level 9
   OK
-Roundtrip testing file decode.c at quality 11
+Roundtrip testing file decode.c at level 11
   OK


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed the compression parameter from "quality" to "level" throughout the user-facing API, documentation, error messages, and test outputs for improved clarity and consistency.
	- Error messages related to compression and decompression have been made more descriptive and consistent.
	- Updated version reporting to use the correct Brotli library version.
- **Tests**
	- Updated test scripts and output to use "level" instead of "quality" for compression parameters.
- **Chores**
	- Added a build flag to indicate when the bundled Brotli implementation is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->