### PR TITLE
Feat/named arguments

### DIFF
--- a/brotli.c
+++ b/brotli.c
@@ -32,35 +32,72 @@ static ZEND_FUNCTION(brotli_compress_add);
 static ZEND_FUNCTION(brotli_uncompress_init);
 static ZEND_FUNCTION(brotli_uncompress_add);
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_brotli_compress, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+    ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, level, IS_LONG, BROTLI_DEFAULT_QUALITY, "BROTLI_COMPRESS_LEVEL_DEFAULT")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, BROTLI_MODE_GENERIC, "BROTLI_GENERIC")
+#else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_compress, 0, 0, 1)
     ZEND_ARG_INFO(0, data)
     ZEND_ARG_INFO(0, level)
     ZEND_ARG_INFO(0, mode)
+#endif
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_brotli_uncompress, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+    ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "0")
+#else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_uncompress, 0, 0, 1)
     ZEND_ARG_INFO(0, data)
     ZEND_ARG_INFO(0, length)
+#endif
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_brotli_compress_init, 0, 0, Brotli\\Compress\\Context, MAY_BE_FALSE)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, level, IS_LONG, BROTLI_DEFAULT_QUALITY, "BROTLI_COMPRESS_LEVEL_DEFAULT")
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, BROTLI_MODE_GENERIC, "BROTLI_GENERIC")
+#else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_compress_init, 0, 0, 0)
     ZEND_ARG_INFO(0, level)
     ZEND_ARG_INFO(0, mode)
+#endif
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_brotli_compress_add, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
+    ZEND_ARG_OBJ_INFO(0, context, Brotli\\Compress\\Context, 0)
+    ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, BROTLI_MODE_GENERIC, "BROTLI_FLUSH")
+#else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_compress_add, 0, 0, 2)
     ZEND_ARG_INFO(0, context)
     ZEND_ARG_INFO(0, data)
     ZEND_ARG_INFO(0, mode)
+#endif
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_brotli_uncompress_init, 0, 0, Brotli\\UnCompress\\Context, MAY_BE_FALSE)
+#else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_uncompress_init, 0, 0, 0)
+#endif
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_brotli_uncompress_add, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
+    ZEND_ARG_OBJ_INFO(0, context, Brotli\\UnCompress\\Context, 0)
+    ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, BROTLI_MODE_GENERIC, "BROTLI_FLUSH")
+#else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_uncompress_add, 0, 0, 2)
     ZEND_ARG_INFO(0, context)
     ZEND_ARG_INFO(0, data)
     ZEND_ARG_INFO(0, mode)
+#endif
 ZEND_END_ARG_INFO()
 
 #if defined(HAVE_APCU_SUPPORT)

--- a/tests/named_args.phpt
+++ b/tests/named_args.phpt
@@ -1,0 +1,127 @@
+--TEST--
+use named arguments
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 80000) die("skip requires PHP 8.0+");
+?>
+--FILE--
+<?php
+include(dirname(__FILE__) . '/data.inc');
+
+$level = BROTLI_COMPRESS_LEVEL_MAX;
+$mode = BROTLI_TEXT;
+
+echo "** brotli_compress() **\n";
+try {
+    var_dump(gettype(brotli_compress()));
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+echo "** brotli_compress(data:) **\n";
+try {
+    var_dump(gettype(brotli_compress(data: $data)));
+    var_dump(brotli_uncompress(brotli_compress(data: $data)) === $data);
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+echo "** brotli_compress(level:) **\n";
+try {
+    var_dump(gettype(brotli_compress(level: $level)));
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+echo "** brotli_compress(mode:) **\n";
+try {
+    var_dump(gettype(brotli_compress(mode: $mode)));
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+echo "** brotli_compress(data:, level:) **\n";
+try {
+    var_dump(gettype(brotli_compress(data: $data, level: $level)));
+    var_dump(brotli_uncompress(brotli_compress(data: $data, level: $level)) === $data);
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+echo "** brotli_compress(data:, mode:) **\n";
+try {
+    var_dump(gettype(brotli_compress(data: $data, mode: $mode)));
+    var_dump(brotli_uncompress(brotli_compress(data: $data, mode: $mode)) === $data);
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+echo "** brotli_compress(level:, mode:) **\n";
+try {
+    var_dump(gettype(brotli_compress(level: $level, mode: $mode)));
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+$compressed = brotli_compress(data: $data);
+
+echo "** brotli_uncompress(): false **\n";
+try {
+    var_dump(gettype(brotli_uncompress()));
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+echo "** brotli_uncompress(data:) **\n";
+try {
+    var_dump(gettype(brotli_uncompress(data: $compressed)));
+    var_dump(brotli_uncompress(data: $compressed) === $data);
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+echo "** brotli_uncompress(length:) **\n";
+try {
+    var_dump(gettype(brotli_uncompress(length: strlen($compressed))));
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+echo "** brotli_uncompress(data: length:) **\n";
+try {
+    var_dump(gettype(brotli_uncompress(data: $compressed, length: strlen($compressed))));
+    var_dump(brotli_uncompress(data: $compressed, length: strlen($compressed)) === $data);
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+?>
+===DONE===
+--EXPECTF--
+** brotli_compress() **
+brotli_compress() expects at least 1 argument, 0 given
+** brotli_compress(data:) **
+string(6) "string"
+bool(true)
+** brotli_compress(level:) **
+brotli_compress(): Argument #1 ($data) not passed
+** brotli_compress(mode:) **
+brotli_compress(): Argument #1 ($data) not passed
+** brotli_compress(data:, level:) **
+string(6) "string"
+bool(true)
+** brotli_compress(data:, mode:) **
+string(6) "string"
+bool(true)
+** brotli_compress(level:, mode:) **
+brotli_compress(): Argument #1 ($data) not passed
+** brotli_uncompress(): false **
+brotli_uncompress() expects at least 1 argument, 0 given
+** brotli_uncompress(data:) **
+string(6) "string"
+bool(true)
+** brotli_uncompress(length:) **
+brotli_uncompress(): Argument #1 ($data) not passed
+** brotli_uncompress(data: length:) **
+string(6) "string"
+bool(true)
+===DONE===

--- a/tests/named_args_incremental.phpt
+++ b/tests/named_args_incremental.phpt
@@ -1,0 +1,127 @@
+--TEST--
+incremental function with use named arguments
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 80000) die("skip requires PHP 8.0+");
+?>
+--FILE--
+<?php
+include(dirname(__FILE__) . '/data.inc');
+
+function test($data, $level = 0, $mode = 0) {
+    echo "level={$level}, mode={$mode}\n";
+
+    $modeTypes = [
+        'BROTLI_PROCESS' => BROTLI_PROCESS,
+        'BROTLI_FLUSH' => BROTLI_FLUSH,
+    ];
+
+    foreach ($modeTypes as $modeTypeKey => $modeType) {
+        $compressed = '';
+
+        $context = brotli_compress_init(
+            level: $level,
+            mode: $mode,
+        );
+        if ($context === false) {
+            echo "ERROR\n";
+            return;
+        }
+        foreach (str_split($data, 6) as $var) {
+            $compressed .= brotli_compress_add(
+                context: $context,
+                data: $var,
+                mode: $modeType,
+            );
+        }
+        $compressed .= brotli_compress_add(
+            context: $context,
+            data: '',
+            mode: BROTLI_FINISH,
+        );
+
+        if ($data === brotli_uncompress(data: $compressed)) {
+            echo "OK\n";
+        } else {
+            echo "ERROR: {$modeTypeKey}\n";
+        }
+
+        $out = '';
+        $context = brotli_uncompress_init();
+        foreach (str_split($compressed, 6) as $var) {
+            $out .= brotli_uncompress_add(
+                context: $context,
+                data: $var,
+                mode: $modeType,
+            );
+        }
+        $out .= brotli_uncompress_add(
+            context: $context,
+            data: '',
+            mode: BROTLI_FINISH,
+        );
+
+        if ($data === $out) {
+            echo "Ok\n";
+        } else {
+            echo "Error: {$modeTypeKey}\n";
+        }
+    }
+}
+
+foreach ([0, 9, 11, 20, -1] as $level) {
+    test($data, $level, 0);
+}
+foreach ([0, 1, 2, 3, -1] as $mode) {
+    test($data, 0, $mode);
+}
+?>
+===DONE===
+--EXPECTF--
+level=0, mode=0
+OK
+Ok
+OK
+Ok
+level=9, mode=0
+OK
+Ok
+OK
+Ok
+level=11, mode=0
+OK
+Ok
+OK
+Ok
+level=20, mode=0
+
+Warning: brotli_compress_init(): failed to compression level (20): must be within 0..11 in %s on line %d
+ERROR
+level=-1, mode=0
+
+Warning: brotli_compress_init(): failed to compression level (-1): must be within 0..11 in %s on line %d
+ERROR
+level=0, mode=0
+OK
+Ok
+OK
+Ok
+level=0, mode=1
+OK
+Ok
+OK
+Ok
+level=0, mode=2
+OK
+Ok
+OK
+Ok
+level=0, mode=3
+
+Warning: brotli_compress_init(): failed to compression mode (3): must be BROTLI_GENERIC(0)|BROTLI_TEXT(1)|BROTLI_FONT(2) in %s on line %d
+ERROR
+level=0, mode=-1
+
+Warning: brotli_compress_init(): failed to compression mode (-1): must be BROTLI_GENERIC(0)|BROTLI_TEXT(1)|BROTLI_FONT(2) in %s on line %d
+ERROR
+===DONE===


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for named arguments in Brotli compression and decompression functions for PHP 8.0 and above.
- **Tests**
  - Introduced new tests to verify Brotli functions with named arguments, including both standard and incremental compression/decompression scenarios.
- **Refactor**
  - Enhanced argument and return type information for Brotli functions on PHP 8.0+, improving type safety and compatibility with reflection tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->