### PR TITLE
Change/uncompress remove length

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The compressed string or FALSE if an error occurred.
 #### Description
 
 ``` php
-brotli_uncompress ( string $data, int $length = 0, string|null $dict = null ): string|false
+brotli_uncompress ( string $data, string|null $dict = null ): string|false
 ```
 
 This function uncompress a compressed string.
@@ -148,10 +148,6 @@ This function uncompress a compressed string.
 * _data_
 
   The data compressed by brotli\_compress().
-
-* _length_
-
-  The maximum length of data to decode.
 
 * _dict_
 
@@ -289,7 +285,7 @@ Returns a chunk of uncompressed data, or FALSE on failure.
 Namespace Brotli;
 
 function compress( string $data, int $level = \BROTLI_COMPRESS_LEVEL_DEFAULT, int $mode = \BROTLI_GENERIC, string|null $dict = null ): string|false {}
-function uncompress( string $data, int $length = 0, string|null $dict = null ): string|false {}
+function uncompress( string $data, string|null $dict = null ): string|false {}
 function compress_init( int $level = \BROTLI_COMPRESS_LEVEL_DEFAULT, int $mode = \BROTLI_GENERIC, string|null $dict = null ): \Brotli\Compress\Context|false {}
 function compress_add( \Brotli\Compress\Context $context, string $data, $mode = \BROTLI_FLUSH ): string|false {}
 function uncompress_init(string|null $dict = null): \Brotli\UnCompress\Context|false {}

--- a/brotli.c
+++ b/brotli.c
@@ -54,12 +54,10 @@ ZEND_END_ARG_INFO()
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_brotli_uncompress, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
     ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "0")
     ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dict, IS_STRING, 1, "null")
 #else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_brotli_uncompress, 0, 0, 1)
     ZEND_ARG_INFO(0, data)
-    ZEND_ARG_INFO(0, length)
 #if defined(USE_BROTLI_DICTIONARY)
     ZEND_ARG_INFO(0, dict)
 #endif
@@ -1663,22 +1661,16 @@ static ZEND_FUNCTION(brotli_compress_add)
 
 static ZEND_FUNCTION(brotli_uncompress)
 {
-    zend_long max_size = 0;
     char *in;
     size_t in_size;
     smart_string out = {0};
     zend_string *dict = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(1, 3)
+    ZEND_PARSE_PARAMETERS_START(1, 2)
         Z_PARAM_STRING(in, in_size)
         Z_PARAM_OPTIONAL
-        Z_PARAM_LONG(max_size)
         Z_PARAM_STR_OR_NULL(dict)
     ZEND_PARSE_PARAMETERS_END();
-
-    if (max_size && max_size < in_size) {
-        in_size = max_size;
-    }
 
     php_brotli_context ctx;
     php_brotli_context_init(&ctx);

--- a/brotli.stub.php
+++ b/brotli.stub.php
@@ -71,7 +71,7 @@ namespace {
   /**
    * @note dict parameter can be used when BROTLI_DICTIONARY_SUPPORT is enabled
    */
-  function brotli_uncompress(string $data, int $length = 0, ?string $dict = null): string|false {}
+  function brotli_uncompress(string $data, ?string $dict = null): string|false {}
 
   /**
    * @note dict parameter can be used when BROTLI_DICTIONARY_SUPPORT is enabled
@@ -98,7 +98,7 @@ namespace Brotli {
   /**
    * @note dict parameter can be used when BROTLI_DICTIONARY_SUPPORT is enabled
    */
-  function uncompress(string $data, int $length = 0, ?string $dict = null): string|false {}
+  function uncompress(string $data, ?string $dict = null): string|false {}
 
   /**
    * @note dict parameter can be used when BROTLI_DICTIONARY_SUPPORT is enabled

--- a/tests/dictionary_args.phpt
+++ b/tests/dictionary_args.phpt
@@ -30,7 +30,7 @@ function check($data, $dictionary, $level, $mode)
         ($dictionary === null ? 'null' : 'dict'), ' -- ',
         var_export(
             (($output === false) ? false
-             : brotli_uncompress($output, 0, $dictionary) === $data),
+             : brotli_uncompress($output, $dictionary) === $data),
             true
         ), PHP_EOL;
 }

--- a/tests/dictionary_basic.phpt
+++ b/tests/dictionary_basic.phpt
@@ -17,15 +17,15 @@ echo "*** Dictionary Compression ***", PHP_EOL;
 $out1 = brotli_compress($data, $level, $mode, $dictionary);
 $out2 = \Brotli\compress($data, $level, $mode, $dictionary);
 
-var_dump(brotli_uncompress($out1, 0, $dictionary) === $data);
-var_dump(brotli_uncompress($out2, 0, $dictionary) === $data);
-var_dump(\Brotli\uncompress($out1, 0, $dictionary) === $data);
-var_dump(\Brotli\uncompress($out2, 0, $dictionary) === $data);
+var_dump(brotli_uncompress($out1, $dictionary) === $data);
+var_dump(brotli_uncompress($out2, $dictionary) === $data);
+var_dump(\Brotli\uncompress($out1, $dictionary) === $data);
+var_dump(\Brotli\uncompress($out2, $dictionary) === $data);
 
 var_dump(brotli_uncompress($out1) === $data);
 var_dump(brotli_uncompress($out2) === $data);
-var_dump(brotli_uncompress($out1, 0, 'dictionary') === $data);
-var_dump(brotli_uncompress($out2, 0, 'dictionary') === $data);
+var_dump(brotli_uncompress($out1, 'dictionary') === $data);
+var_dump(brotli_uncompress($out2, 'dictionary') === $data);
 ?>
 ===DONE===
 --EXPECTF--

--- a/tests/dictionary_incremental.phpt
+++ b/tests/dictionary_incremental.phpt
@@ -26,7 +26,7 @@ foreach ($modeTypes as $modeTypeKey => $modeType) {
     }
     $compressed .= brotli_compress_add($context, '', BROTLI_FINISH);
 
-    if ($data === brotli_uncompress($compressed, 0, $dictionary)) {
+    if ($data === brotli_uncompress($compressed, $dictionary)) {
         echo "OK: {$modeTypeKey}\n";
     } else {
         echo "ERROR: {$modeTypeKey}\n";

--- a/tests/dictionary_named_args.phpt
+++ b/tests/dictionary_named_args.phpt
@@ -80,21 +80,6 @@ try {
 } catch (Error $e) {
     echo $e->getMessage(), PHP_EOL;
 }
-
-echo "** brotli_uncompress(length:, dict:) **\n";
-try {
-    var_dump(gettype(brotli_uncompress(length: strlen($compressed), dict: $dictionary)));
-} catch (Error $e) {
-    echo $e->getMessage(), PHP_EOL;
-}
-
-echo "** brotli_uncompress(data: length:, dict:) **\n";
-try {
-    var_dump(gettype(brotli_uncompress(data: $compressed, length: strlen($compressed), dict: $dictionary)));
-    var_dump(brotli_uncompress(data: $compressed, length: strlen($compressed), dict: $dictionary) === $data);
-} catch (Error $e) {
-    echo $e->getMessage(), PHP_EOL;
-}
 ?>
 ===DONE===
 --EXPECTF--
@@ -118,11 +103,6 @@ brotli_compress(): Argument #1 ($data) not passed
 ** brotli_uncompress(dict:): false **
 brotli_uncompress(): Argument #1 ($data) not passed
 ** brotli_uncompress(data:, dict:) **
-string(6) "string"
-bool(true)
-** brotli_uncompress(length:, dict:) **
-brotli_uncompress(): Argument #1 ($data) not passed
-** brotli_uncompress(data: length:, dict:) **
 string(6) "string"
 bool(true)
 ===DONE===

--- a/tests/dictionary_streams.phpt
+++ b/tests/dictionary_streams.phpt
@@ -30,7 +30,7 @@ $decomp = file_get_contents('compress.brotli://' . $file, false, $ctx);
 var_dump($decomp == $data);
 
 $comp = file_get_contents($file);
-$decomp = brotli_uncompress($comp, 0, $dictionary);
+$decomp = brotli_uncompress($comp, $dictionary);
 var_dump($decomp == $data);
 
 @unlink($file);

--- a/tests/named_args.phpt
+++ b/tests/named_args.phpt
@@ -79,21 +79,6 @@ try {
 } catch (Error $e) {
     echo $e->getMessage(), PHP_EOL;
 }
-
-echo "** brotli_uncompress(length:) **\n";
-try {
-    var_dump(gettype(brotli_uncompress(length: strlen($compressed))));
-} catch (Error $e) {
-    echo $e->getMessage(), PHP_EOL;
-}
-
-echo "** brotli_uncompress(data: length:) **\n";
-try {
-    var_dump(gettype(brotli_uncompress(data: $compressed, length: strlen($compressed))));
-    var_dump(brotli_uncompress(data: $compressed, length: strlen($compressed)) === $data);
-} catch (Error $e) {
-    echo $e->getMessage(), PHP_EOL;
-}
 ?>
 ===DONE===
 --EXPECTF--
@@ -117,11 +102,6 @@ brotli_compress(): Argument #1 ($data) not passed
 ** brotli_uncompress(): false **
 brotli_uncompress() expects at least 1 argument, 0 given
 ** brotli_uncompress(data:) **
-string(6) "string"
-bool(true)
-** brotli_uncompress(length:) **
-brotli_uncompress(): Argument #1 ($data) not passed
-** brotli_uncompress(data: length:) **
 string(6) "string"
 bool(true)
 ===DONE===


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to remove references to the unused `$length` parameter in the `brotli_uncompress` function.
- **Bug Fixes**
  - Simplified the `brotli_uncompress` and `Brotli\uncompress` function signatures by removing the unused `$length` parameter.
- **Tests**
  - Updated tests to match the new function signatures and removed test cases related to the removed `$length` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->