### PR TITLE
Add/version constants

### DIFF
--- a/brotli.c
+++ b/brotli.c
@@ -1309,6 +1309,18 @@ ZEND_MINIT_FUNCTION(brotli)
                            CONST_CS | CONST_PERSISTENT);
 #endif
 
+    uint32_t version_number = BrotliDecoderVersion();
+    char version_text[64];
+    snprintf(version_text, sizeof(version_text), "%d.%d.%d",
+             version_number >> 24,
+             (version_number >> 12) & 0xfff,
+             version_number & 0xfff);
+
+    REGISTER_LONG_CONSTANT("BROTLI_VERSION_NUMBER", version_number,
+                           CONST_CS | CONST_PERSISTENT);
+    REGISTER_STRING_CONSTANT("BROTLI_VERSION_TEXT", version_text,
+                             CONST_CS | CONST_PERSISTENT);
+
     php_output_handler_alias_register(ZEND_STRL(PHP_BROTLI_OUTPUT_HANDLER),
                                       php_brotli_output_handler_init);
     php_output_handler_conflict_register(ZEND_STRL(PHP_BROTLI_OUTPUT_HANDLER),

--- a/brotli.c
+++ b/brotli.c
@@ -1425,15 +1425,9 @@ ZEND_MINFO_FUNCTION(brotli)
     php_info_print_table_start();
     php_info_print_table_row(2, "Brotli support", "enabled");
     php_info_print_table_row(2, "Extension Version", BROTLI_EXT_VERSION);
-#ifdef BROTLI_LIB_VERSION
-    php_info_print_table_row(2, "Library Version", BROTLI_LIB_VERSION);
-#else
-    uint32_t version = BrotliDecoderVersion();
-    char buffer[64];
-    snprintf(buffer, sizeof(buffer), "%d.%d.%d",
-             version >> 24, (version >> 12) & 0xfff, version & 0xfff);
-    php_info_print_table_row(2, "Library Version", buffer);
-#endif
+    const zval *ver = zend_get_constant_str("BROTLI_VERSION_TEXT",
+                                            sizeof("BROTLI_VERSION_TEXT") - 1);
+    php_info_print_table_row(2, "Library Version", Z_STRVAL_P(ver));
 #if defined(USE_BROTLI_DICTIONARY)
     php_info_print_table_row(2, "Dictionary support", "enabled");
 #else

--- a/brotli.stub.php
+++ b/brotli.stub.php
@@ -64,6 +64,18 @@ namespace {
   const BROTLI_DICTIONARY_SUPPORT = UNKNOWN;
 
   /**
+   * @var string
+   * @cvalue BROTLI_VERSION_TEXT
+   */
+  const BROTLI_VERSION_TEXT = UNKNOWN;
+
+  /**
+   * @var int
+   * @cvalue BROTLI_VERSION_NUMBER
+   */
+  const BROTLI_VERSION_NUMBER = UNKNOWN;
+
+  /**
    * @note dict parameter can be used when BROTLI_DICTIONARY_SUPPORT is enabled
    */
   function brotli_compress(string $data, int $level = BROTLI_COMPRESS_LEVEL_DEFAULT, int $mode = BROTLI_GENERIC, ?string $dict = null): string|false {}

--- a/config.m4
+++ b/config.m4
@@ -62,7 +62,6 @@ if test "$PHP_BROTLI" != "no"; then
     fi
     PHP_EVAL_INCLINE($LIBBROTLIDEC_CFLAGS)
     PHP_EVAL_LIBLINE($LIBBROTLIDEC_LIBS, BROTLI_SHARED_LIBADD)
-    AC_DEFINE_UNQUOTED(BROTLI_LIB_VERSION, "$LIBBROTLIDEC_VERSION", [system library version])
 
     AC_MSG_CHECKING(for brotli dictionary)
     if $PKG_CONFIG libbrotlidec --atleast-version 1.1.0; then

--- a/php_brotli.h
+++ b/php_brotli.h
@@ -5,7 +5,6 @@
 extern "C" {
 #endif
 
-/* Don't forget to check BROTLI_LIB_VERSION in config.m4/w32 */
 #define BROTLI_EXT_VERSION "0.17.0"
 #define BROTLI_NS "Brotli"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced two new constants, BROTLI_VERSION_NUMBER and BROTLI_VERSION_TEXT, providing access to the Brotli library version as an integer and a human-readable string.
- **Documentation**
  - Updated extension stubs to include the newly added version constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->