### PR TITLE
use Zend/zend_smart_string.h

### DIFF
--- a/brotli.c
+++ b/brotli.c
@@ -10,7 +10,11 @@
 #include <ext/standard/base64.h>
 #include <ext/standard/file.h>
 #include <ext/standard/info.h>
+#if PHP_VERSION_ID < 70200
 #include <ext/standard/php_smart_string.h>
+#else
+#include <Zend/zend_smart_string.h>
+#endif
 #if defined(HAVE_APCU_SUPPORT)
 #include <ext/standard/php_var.h>
 #include <ext/apcu/apc_serializer.h>


### PR DESCRIPTION
* `Zend/zend_smart_string.h` exists since 7.2
* `ext/standard/php_smart_string.h` removed in 8.5.0alpha3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compatibility with various PHP versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->