### PR TITLE
Update brotli submodule to v1.2.0

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -103,13 +103,17 @@ if test "$PHP_BROTLI" != "no"; then
       brotli/c/enc/memory.c
       brotli/c/enc/metablock.c
       brotli/c/enc/static_dict.c
+      brotli/c/enc/static_dict_lut.c
+      brotli/c/enc/static_init.c
       brotli/c/enc/utf8_util.c
     "
     BROTLI_DEC_SOURCES="
       brotli/c/dec/bit_reader.c
       brotli/c/dec/decode.c
       brotli/c/dec/huffman.c
+      brotli/c/dec/prefix.c
       brotli/c/dec/state.c
+      brotli/c/dec/static_init.c
     "
 
     AC_DEFINE(USE_BROTLI_BUNDLED, 1, [use bundled])

--- a/config.w32
+++ b/config.w32
@@ -14,17 +14,55 @@ if (PHP_BROTLI != "no") {
     EXTENSION("brotli", "brotli.c", PHP_BROTLI_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
     ADD_SOURCES(
       "brotli/c/common",
-      "constants.c context.c dictionary.c platform.c shared_dictionary.c transform.c",
+      [
+        "constants.c",
+        "context.c",
+        "dictionary.c",
+        "platform.c",
+        "shared_dictionary.c",
+        "transform.c"
+      ].join(" "),
       "brotli",
       "brotli\\c\\common");
     ADD_SOURCES(
       "brotli/c/enc",
-      "backward_references.c backward_references_hq.c bit_cost.c block_splitter.c brotli_bit_stream.c cluster.c command.c compound_dictionary.c compress_fragment.c compress_fragment_two_pass.c dictionary_hash.c encode.c encoder_dict.c entropy_encode.c fast_log.c histogram.c literal_cost.c memory.c metablock.c static_dict.c static_dict_lut.c static_init.c utf8_util.c",
+      [
+        "backward_references.c",
+        "backward_references_hq.c",
+        "bit_cost.c",
+        "block_splitter.c",
+        "brotli_bit_stream.c",
+        "cluster.c",
+        "command.c",
+        "compound_dictionary.c",
+        "compress_fragment.c",
+        "compress_fragment_two_pass.c",
+        "dictionary_hash.c",
+        "encode.c",
+        "encoder_dict.c",
+        "entropy_encode.c",
+        "fast_log.c",
+        "histogram.c",
+        "literal_cost.c",
+        "memory.c",
+        "metablock.c",
+        "static_dict.c",
+        "static_dict_lut.c",
+        "static_init.c",
+        "utf8_util.c"
+      ].join(" "),
       "brotli",
       "brotli\\c\\enc");
     ADD_SOURCES(
       "brotli/c/dec",
-      "bit_reader.c decode.c huffman.c prefix.c state.c static_init.c",
+      [
+        "bit_reader.c",
+        "decode.c",
+        "huffman.c",
+        "prefix.c",
+        "state.c",
+        "static_init.c"
+      ].join(" "),
       "brotli",
       "brotli\\c\\dec");
 

--- a/config.w32
+++ b/config.w32
@@ -13,8 +13,8 @@ if (PHP_BROTLI != "no") {
   } else {
     EXTENSION("brotli", "brotli.c", PHP_BROTLI_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
     ADD_SOURCES("brotli/c/common", "constants.c context.c dictionary.c platform.c shared_dictionary.c transform.c", "brotli");
-    ADD_SOURCES("brotli/c/enc", "backward_references.c backward_references_hq.c bit_cost.c block_splitter.c brotli_bit_stream.c cluster.c command.c compound_dictionary.c compress_fragment.c compress_fragment_two_pass.c dictionary_hash.c encode.c encoder_dict.c entropy_encode.c fast_log.c histogram.c literal_cost.c memory.c metablock.c static_dict.c utf8_util.c", "brotli");
-    ADD_SOURCES("brotli/c/dec", "bit_reader.c decode.c huffman.c state.c", "brotli");
+    ADD_SOURCES("brotli/c/enc", "backward_references.c backward_references_hq.c bit_cost.c block_splitter.c brotli_bit_stream.c cluster.c command.c compound_dictionary.c compress_fragment.c compress_fragment_two_pass.c dictionary_hash.c encode.c encoder_dict.c entropy_encode.c fast_log.c histogram.c literal_cost.c memory.c metablock.c static_dict.c static_dict_lut.c static_init.c utf8_util.c", "brotli");
+    ADD_SOURCES("brotli/c/dec", "bit_reader.c decode.c huffman.c prefix.c state.c static_init.c", "brotli");
 
     ADD_FLAG("CFLAGS_BROTLI", " /I" + configure_module_dirname + " /I" + configure_module_dirname + "/brotli/c/include");
 

--- a/config.w32
+++ b/config.w32
@@ -12,9 +12,21 @@ if (PHP_BROTLI != "no") {
     }
   } else {
     EXTENSION("brotli", "brotli.c", PHP_BROTLI_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-    ADD_SOURCES("brotli/c/common", "constants.c context.c dictionary.c platform.c shared_dictionary.c transform.c", "brotli");
-    ADD_SOURCES("brotli/c/enc", "backward_references.c backward_references_hq.c bit_cost.c block_splitter.c brotli_bit_stream.c cluster.c command.c compound_dictionary.c compress_fragment.c compress_fragment_two_pass.c dictionary_hash.c encode.c encoder_dict.c entropy_encode.c fast_log.c histogram.c literal_cost.c memory.c metablock.c static_dict.c static_dict_lut.c static_init.c utf8_util.c", "brotli");
-    ADD_SOURCES("brotli/c/dec", "bit_reader.c decode.c huffman.c prefix.c state.c static_init.c", "brotli");
+    ADD_SOURCES(
+      "brotli/c/common",
+      "constants.c context.c dictionary.c platform.c shared_dictionary.c transform.c",
+      "brotli",
+      "brotli\\c\\common");
+    ADD_SOURCES(
+      "brotli/c/enc",
+      "backward_references.c backward_references_hq.c bit_cost.c block_splitter.c brotli_bit_stream.c cluster.c command.c compound_dictionary.c compress_fragment.c compress_fragment_two_pass.c dictionary_hash.c encode.c encoder_dict.c entropy_encode.c fast_log.c histogram.c literal_cost.c memory.c metablock.c static_dict.c static_dict_lut.c static_init.c utf8_util.c",
+      "brotli",
+      "brotli\\c\\enc");
+    ADD_SOURCES(
+      "brotli/c/dec",
+      "bit_reader.c decode.c huffman.c prefix.c state.c static_init.c",
+      "brotli",
+      "brotli\\c\\dec");
 
     ADD_FLAG("CFLAGS_BROTLI", " /I" + configure_module_dirname + " /I" + configure_module_dirname + "/brotli/c/include");
 

--- a/tests/compatibility.phpt
+++ b/tests/compatibility.phpt
@@ -234,3 +234,7 @@ Testing decompression of file zeros.compressed
   read uncompressed .. OK
   compressed        .. OK
   uncompressed      .. OK
+Testing decompression of file zerosukkanooa.compressed
+  read uncompressed .. OK
+  compressed        .. OK
+  uncompressed      .. OK


### PR DESCRIPTION
See also https://github.com/google/brotli/releases/tag/v1.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated bundled Brotli to a newer tracked revision.
  * Enhanced build configuration for Windows and Unix to include additional Brotli modules for improved compression support.

* **Tests**
  * Added a new compression compatibility test case covering an additional compressed sample.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->