### PR TITLE
Fix UBSAN issue by switching to `smart_str`

### DIFF
--- a/brotli.c
+++ b/brotli.c
@@ -122,6 +122,19 @@ static int APC_SERIALIZER_NAME(brotli)(APC_SERIALIZER_ARGS);
 static int APC_UNSERIALIZER_NAME(brotli)(APC_UNSERIALIZER_ARGS);
 #endif
 
+#if PHP_VERSION_ID < 70200
+static zend_always_inline zend_string *smart_str_extract(smart_str *str) {
+	if (str->s) {
+		smart_str_0(str);
+		zend_string *res = str->s;
+		str->s = NULL;
+		return res;
+	} else {
+		return ZSTR_EMPTY_ALLOC();
+	}
+}
+#endif
+
 static zend_function_entry brotli_functions[] = {
     ZEND_FE(brotli_compress, arginfo_brotli_compress)
     ZEND_FE(brotli_uncompress, arginfo_brotli_uncompress)

--- a/brotli.c
+++ b/brotli.c
@@ -10,15 +10,10 @@
 #include <ext/standard/base64.h>
 #include <ext/standard/file.h>
 #include <ext/standard/info.h>
-#if PHP_VERSION_ID < 70200
-#include <ext/standard/php_smart_string.h>
-#else
-#include <Zend/zend_smart_string.h>
-#endif
+#include <zend_smart_str.h>
 #if defined(HAVE_APCU_SUPPORT)
 #include <ext/standard/php_var.h>
 #include <ext/apcu/apc_serializer.h>
-#include <zend_smart_str.h>
 #endif
 #include <Zend/zend_interfaces.h>
 #if defined(USE_BROTLI_BUNDLED)
@@ -1522,7 +1517,7 @@ static ZEND_FUNCTION(brotli_compress)
 
     ctx.next_in = (const uint8_t *)in;
     ctx.available_in = in_size;
-    smart_string out = {0};
+    smart_str out = {0};
     while (!BrotliEncoderIsFinished(ctx.encoder)) {
         ctx.available_out = buffer_size;
         ctx.next_out = buffer;
@@ -1532,11 +1527,11 @@ static ZEND_FUNCTION(brotli_compress)
                                         0)) {
             size_t used_out = (size_t)(ctx.next_out - buffer);
             if (used_out) {
-                smart_string_appendl(&out, buffer, used_out);
+                smart_str_appendl(&out, buffer, used_out);
             }
         } else {
             efree(buffer);
-            smart_string_free(&out);
+            smart_str_free(&out);
             php_error_docref(NULL, E_WARNING, "failed to compress");
             php_brotli_context_close(&ctx);
             RETURN_FALSE;
@@ -1545,10 +1540,9 @@ static ZEND_FUNCTION(brotli_compress)
 
     php_brotli_context_close(&ctx);
 
-    RETVAL_STRINGL(out.c, out.len);
+    RETVAL_STR(smart_str_extract(&out));
 
     efree(buffer);
-    smart_string_free(&out);
 }
 
 static ZEND_FUNCTION(brotli_compress_init)
@@ -1586,7 +1580,7 @@ static ZEND_FUNCTION(brotli_compress_add)
 #endif
     char *in_buf;
     size_t in_size;
-    smart_string out = {0};
+    smart_str out = {0};
 
     ZEND_PARSE_PARAMETERS_START(2, 3)
 #if PHP_VERSION_ID >= 80000
@@ -1641,11 +1635,11 @@ static ZEND_FUNCTION(brotli_compress_add)
                                         0)) {
             buffer_used = (size_t)(ctx->next_out - buffer);
             if (buffer_used) {
-                smart_string_appendl(&out, buffer, buffer_used);
+                smart_str_appendl(&out, buffer, buffer_used);
             }
         } else {
             efree(buffer);
-            smart_string_free(&out);
+            smart_str_free(&out);
             php_error_docref(NULL, E_WARNING,
                              "failed to incremental compress");
             RETURN_FALSE;
@@ -1665,11 +1659,11 @@ static ZEND_FUNCTION(brotli_compress_add)
                                             0)) {
                 buffer_used = (size_t)(ctx->next_out - buffer);
                 if (buffer_used) {
-                    smart_string_appendl(&out, buffer, buffer_used);
+                    smart_str_appendl(&out, buffer, buffer_used);
                 }
             } else {
                 efree(buffer);
-                smart_string_free(&out);
+                smart_str_free(&out);
                 php_error_docref(NULL, E_WARNING,
                                  "failed to incremental compress");
                 RETURN_FALSE;
@@ -1677,17 +1671,16 @@ static ZEND_FUNCTION(brotli_compress_add)
         }
     }
 
-    RETVAL_STRINGL(out.c, out.len);
+    RETVAL_STR(smart_str_extract(&out));
 
     efree(buffer);
-    smart_string_free(&out);
 }
 
 static ZEND_FUNCTION(brotli_uncompress)
 {
     char *in;
     size_t in_size;
-    smart_string out = {0};
+    smart_str out = {0};
     zend_string *dict = NULL;
 
     ZEND_PARSE_PARAMETERS_START(1, 2)
@@ -1719,7 +1712,7 @@ static ZEND_FUNCTION(brotli_uncompress)
                                                0);
         size_t used_out = (size_t)(buffer_size - ctx.available_out);
         if (used_out != 0) {
-            smart_string_appendl(&out, buffer, used_out);
+            smart_str_appendl(&out, buffer, used_out);
         }
     }
 
@@ -1728,12 +1721,11 @@ static ZEND_FUNCTION(brotli_uncompress)
 
     if (result != BROTLI_DECODER_RESULT_SUCCESS) {
         php_error_docref(NULL, E_WARNING, "failed to uncompress");
-        smart_string_free(&out);
+        smart_str_free(&out);
         RETURN_FALSE;
     }
 
-    RETVAL_STRINGL(out.c, out.len);
-    smart_string_free(&out);
+    RETVAL_STR(smart_str_extract(&out));
 }
 
 static ZEND_FUNCTION(brotli_uncompress_init)
@@ -1766,7 +1758,7 @@ static ZEND_FUNCTION(brotli_uncompress_add)
 #endif
     char *in_buf;
     size_t in_size;
-    smart_string out = {0};
+    smart_str out = {0};
 
     ZEND_PARSE_PARAMETERS_START(2, 3)
 #if PHP_VERSION_ID >= 80000
@@ -1823,14 +1815,13 @@ static ZEND_FUNCTION(brotli_uncompress_add)
                                                0);
         size_t buffer_used = buffer_size - ctx->available_out;
         if (buffer_used) {
-            smart_string_appendl(&out, buffer, buffer_used);
+            smart_str_appendl(&out, buffer, buffer_used);
         }
     }
 
-    RETVAL_STRINGL(out.c, out.len);
+    RETVAL_STR(smart_str_extract(&out));
 
     efree(buffer);
-    smart_string_free(&out);
 }
 
 #if defined(HAVE_APCU_SUPPORT)


### PR DESCRIPTION
When a `smart_string` is never updated, it's `c` field remains NULL. This is possible with a brotli library failure or with an empty output. This is triggerable via e.g. `uncompress_add()`.
When that happens, a NULL pointer is passed to `zend_string_init()` which is not allowed and will cause undefined behaviour in the subsequent `memcpy()` call that `zend_string_init()` performs.

One way to fix this would be to guard the invocation of `RETVAL_STRINGL()`. However, a cleaner way is to switch to the `smart_str` API which handles everything already nicely for us.
As a bonus, `smart_str` will avoid reallocation of the string, so the new code is not only cleaner but also faster.

Example UBSAN report:
```
/usr/local/include/php/Zend/zend_string.h:191:2: runtime error: null pointer passed as argument 2, which is declared to never be null
    #0 0x7c8d9852a291 in zend_string_init /usr/local/include/php/Zend/zend_string.h:191
    #1 0x7c8d98535adf in zif_brotli_uncompress_add /work/php-ext-brotli/brotli.c:1830
    #2 0x623731f73e26 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #3 0x6237323a22bd in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #4 0x62373259894d in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #5 0x6237325a9126 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #6 0x623732779b56 in zend_execute_script /work/php-src/Zend/zend.c:1980
    #7 0x623731fa8cce in php_execute_script_ex /work/php-src/main/main.c:2645
    #8 0x623731fa8fd8 in php_execute_script /work/php-src/main/main.c:2685
    #9 0x623732791599 in main /work/php-src/sapi/cgi/cgi_main.c:2529
    #10 0x7c8d9a8381c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #11 0x7c8d9a83828a in __libc_start_main_impl ../csu/libc-start.c:360
    #12 0x623730c09ad4 in _start (/work/php-src/build-dbg-ubsan/sapi/cgi/php-cgi+0x1409ad4) (BuildId: 4ad96c24d1e97297ff4db76de2af34c057b26433)
```

Note: this was found by a hybrid static-dynamic analyzer I'm developing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal overhaul of Brotli compression/decompression buffering for more robust, maintainable, and slightly more efficient output handling. No changes to public APIs, function signatures, or behavior visible to callers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kjdev/php-ext-brotli/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->