### PR TITLE
Fix #84: Failure in brotli_uncompress_add() is not propagated to the user

### DIFF
--- a/brotli.c
+++ b/brotli.c
@@ -1832,9 +1832,15 @@ static ZEND_FUNCTION(brotli_uncompress_add)
         }
     }
 
-    RETVAL_STR(smart_str_extract(&out));
-
     efree(buffer);
+
+    if (result == BROTLI_DECODER_RESULT_ERROR) {
+        php_error_docref(NULL, E_WARNING, "failed to uncompress");
+        smart_str_free(&out);
+        RETURN_FALSE;
+    }
+
+    RETURN_STR(smart_str_extract(&out));
 }
 
 #if defined(HAVE_APCU_SUPPORT)


### PR DESCRIPTION
Crucially, must check against hard errors
(`BROTLI_DECODER_RESULT_ERROR`) not against
`BROTLI_DECODER_RESULT_SUCCESS` because then `NEEDS_MORE_INPUT` is misinterpreted as error.

Note: this was found by a hybrid static-dynamic analyzer I'm developing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and reporting for Brotli decompression operations. The system now properly detects and emits warnings when decompression errors occur, while ensuring proper resource cleanup in all scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kjdev/php-ext-brotli/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->