### PR TITLE
configurable compression level for apcu

### DIFF
--- a/brotli.c
+++ b/brotli.c
@@ -784,6 +784,12 @@ PHP_INI_BEGIN()
   STD_PHP_INI_ENTRY("brotli.output_compression_dict", "",
                     PHP_INI_ALL, OnUpdateString, output_compression_dict,
                     zend_brotli_globals, brotli_globals)
+#if defined(HAVE_APCU_SUPPORT)
+  STD_PHP_INI_ENTRY("brotli.apcu_compression_level",
+                    TOSTRING(BROTLI_DEFAULT_QUALITY),
+                    PHP_INI_ALL, OnUpdateLong, apcu_compression_level,
+                    zend_brotli_globals, brotli_globals)
+#endif
 PHP_INI_END()
 
 static void php_brotli_init_globals(zend_brotli_globals *brotli_globals)
@@ -1452,6 +1458,7 @@ ZEND_MINFO_FUNCTION(brotli)
     php_info_print_table_row(2, "APCu serializer ABI", APC_SERIALIZER_ABI);
 #endif
     php_info_print_table_end();
+    DISPLAY_INI_ENTRIES();
 }
 
 #if defined(HAVE_APCU_SUPPORT)
@@ -1837,10 +1844,15 @@ static ZEND_FUNCTION(brotli_uncompress_add)
 static int APC_SERIALIZER_NAME(brotli)(APC_SERIALIZER_ARGS)
 {
     int result;
-    int lgwin = BROTLI_DEFAULT_WINDOW, level = BROTLI_DEFAULT_QUALITY;
+    int lgwin = BROTLI_DEFAULT_WINDOW;
+    long level = BROTLI_G(apcu_compression_level);
     php_serialize_data_t var_hash;
     smart_str var = {0};
     BrotliEncoderMode mode = BROTLI_MODE_GENERIC;
+
+    if (level < BROTLI_MIN_QUALITY || level > BROTLI_MAX_QUALITY) {
+        level = BROTLI_DEFAULT_QUALITY;
+    }
 
     PHP_VAR_SERIALIZE_INIT(var_hash);
     php_var_serialize(&var, (zval*) value, &var_hash);

--- a/php_brotli.h
+++ b/php_brotli.h
@@ -30,6 +30,9 @@ extern zend_module_entry brotli_module_entry;
 typedef struct _php_brotli_context php_brotli_context;
 
 ZEND_BEGIN_MODULE_GLOBALS(brotli)
+#if defined(HAVE_APCU_SUPPORT)
+  zend_long apcu_compression_level;
+#endif
   zend_long output_compression;
   zend_long output_compression_default;
   zend_long output_compression_level;

--- a/tests/apcu_serializer.phpt
+++ b/tests/apcu_serializer.phpt
@@ -65,6 +65,32 @@ var_dump($unserialized);
 if ($unserialized[0] === $unserialized[1]) {
   echo "SAME\n";
 }
+
+function getEntrySize(string $key) {
+  $info = apcu_cache_info();
+  if (!is_array($info) || !isset($info['cache_list']) || !is_array($info['cache_list'])) {
+    return null;
+  }
+  foreach($info['cache_list'] as $entry) {
+    if (($entry['info'] ?? null) === $key) {
+      return $entry['mem_size'];
+    }
+  }
+  return null;
+}
+include(dirname(__FILE__) . '/data.inc');
+
+ini_set('brotli.apcu_compression_level', BROTLI_COMPRESS_LEVEL_MIN);
+apcu_store('size_test', [$data]);
+$a = getEntrySize('size_test');
+
+ini_set('brotli.apcu_compression_level', BROTLI_COMPRESS_LEVEL_MAX);
+apcu_store('size_test', [$data]);
+$b = getEntrySize('size_test');
+
+if ($a !== null && $b !== null && $b < $a) {
+  echo "SMALLER\n";
+}
 ?>
 --EXPECTF--
 brotli
@@ -104,3 +130,4 @@ array(2) {
   }
 }
 SAME
+SMALLER


### PR DESCRIPTION
New ini setting "brotli.apcu_compression_level"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added brotli.apcu_compression_level runtime option to control Brotli compression with APCu.
  * Extension INI entries are now shown in phpinfo().

* **Bug Fixes**
  * Compression level values outside the allowed range now fall back to the default.

* **Tests**
  * Added test to verify Brotli compression efficiency at different APCu compression levels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kjdev/php-ext-brotli/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->