### PR TITLE
Add MIME Type Exclusions for Transparent Output Compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ extension=brotli.so
 
 ### Output handler option
 
-Name                              | Default | Changeable
---------------------------------- | ------- | ----------
-brotli.output\_compression        | 0       | PHP\_INI\_ALL
-brotli.output\_compression\_level | 11      | PHP\_INI\_ALL
-brotli.output\_compression\_dict  | ""      | PHP\_INI\_ALL
+Name                                           | Default | Changeable
+---------------------------------------------- | ------- | ----------
+brotli.output\_compression                     | 0       | PHP\_INI\_ALL
+brotli.output\_compression\_level              | 11      | PHP\_INI\_ALL
+brotli.output\_compression\_exclude\_types    | ""      | PHP\_INI\_ALL
+brotli.output\_compression\_dict               | ""      | PHP\_INI\_ALL
 
 * brotli.output\_compression _boolean_
 
@@ -60,6 +61,27 @@ brotli.output\_compression\_dict  | ""      | PHP\_INI\_ALL
     Compression level used for transparent output compression.
     Specify a value between 0 to 11.
     The default value of `BROTLI_COMPRESS_LEVEL_DEFAULT` (11).
+
+* brotli.output\_compression\_exclude\_types _string_
+
+    Comma-separated list of MIME types that should not be
+    compressed by the transparent output handler.
+
+    Supports exact MIME type matches and wildcard family matches.
+    A wildcard entry must use the `type/*` form.
+
+    Examples:
+
+    ```ini
+    brotli.output_compression_exclude_types="image/*,video/*,audio/*"
+    ```
+
+    ```ini
+    brotli.output_compression_exclude_types="application/pdf,application/zip"
+    ```
+
+    This is useful for already-compressed binary formats where
+    additional Brotli compression usually provides little benefit.
 
 * brotli.output\_compression\_dict _string_
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Name                                           | Default | Changeable
 ---------------------------------------------- | ------- | ----------
 brotli.output\_compression                     | 0       | PHP\_INI\_ALL
 brotli.output\_compression\_level              | 11      | PHP\_INI\_ALL
-brotli.output\_compression\_exclude\_types    | ""      | PHP\_INI\_ALL
+brotli.output\_compression\_exclude\_types     | ""      | PHP\_INI\_ALL
 brotli.output\_compression\_dict               | ""      | PHP\_INI\_ALL
 
 * brotli.output\_compression _boolean_

--- a/brotli.c
+++ b/brotli.c
@@ -392,7 +392,11 @@ static int php_brotli_output_mimetype_excluded(void)
 		return 0;
 	}
 
-	mimetype_len = strlen(mimetype);
+	end = mimetype;
+	while (*end && *end != ';' && *end != ' ' && *end != '\t' && *end != '\r' && *end != '\n') {
+		end++;
+	}
+	mimetype_len = end - mimetype;
 	p = exclude;
 
 	while (*p) {

--- a/brotli.c
+++ b/brotli.c
@@ -380,6 +380,57 @@ static int php_brotli_output_encoding(void)
     return BROTLI_G(compression_coding);
 }
 
+
+static int php_brotli_output_mimetype_excluded(void)
+{
+	const char *mimetype = SG(sapi_headers).mimetype;
+	const char *exclude = BROTLI_G(output_compression_exclude_types);
+	const char *p, *end;
+	size_t mimetype_len;
+
+	if (!mimetype || !*mimetype || !exclude || !*exclude) {
+		return 0;
+	}
+
+	mimetype_len = strlen(mimetype);
+	p = exclude;
+
+	while (*p) {
+		size_t token_len;
+
+		while (*p == ',' || *p == ' ' || *p == '\t' || *p == '\r' || *p == '\n') {
+			p++;
+		}
+
+		end = p;
+		while (*end && *end != ',' && *end != ' ' && *end != '\t' && *end != '\r' && *end != '\n') {
+			end++;
+		}
+
+		token_len = end - p;
+
+		if (token_len > 0) {
+			if (token_len >= 2 && p[token_len - 2] == '/' && p[token_len - 1] == '*') {
+				size_t prefix_len = token_len - 1;
+
+				if (mimetype_len >= prefix_len &&
+					!strncasecmp(mimetype, p, prefix_len)) {
+					return 1;
+				}
+			}
+
+			if (mimetype_len == token_len &&
+				!strncasecmp(mimetype, p, token_len)) {
+				return 1;
+			}
+		}
+
+		p = end;
+	}
+
+	return 0;
+}
+
 static zend_string *php_brotli_output_handler_load_dict(php_brotli_context *ctx)
 {
     char *file = BROTLI_G(output_compression_dict);
@@ -499,6 +550,12 @@ static int php_brotli_output_handler(void **handler_context,
                                      php_output_context *output_context)
 {
     php_brotli_context *ctx = *(php_brotli_context **)handler_context;
+
+	if ((output_context->op & PHP_OUTPUT_HANDLER_START) &&
+		php_brotli_output_mimetype_excluded()) {
+		return FAILURE;
+	}
+
 
     if (!php_brotli_output_encoding()) {
         if ((output_context->op & PHP_OUTPUT_HANDLER_START)
@@ -781,7 +838,11 @@ PHP_INI_BEGIN()
                     TOSTRING(BROTLI_DEFAULT_QUALITY),
                     PHP_INI_ALL, OnUpdateLong, output_compression_level,
                     zend_brotli_globals, brotli_globals)
-  STD_PHP_INI_ENTRY("brotli.output_compression_dict", "",
+  STD_PHP_INI_ENTRY("brotli.output_compression_exclude_types", "",
+		PHP_INI_ALL, OnUpdateString,
+		output_compression_exclude_types,
+		zend_brotli_globals, brotli_globals)
+	STD_PHP_INI_ENTRY("brotli.output_compression_dict", "",
                     PHP_INI_ALL, OnUpdateString, output_compression_dict,
                     zend_brotli_globals, brotli_globals)
 #if defined(HAVE_APCU_SUPPORT)
@@ -797,6 +858,7 @@ static void php_brotli_init_globals(zend_brotli_globals *brotli_globals)
     brotli_globals->handler_registered = 0;
     brotli_globals->compression_coding = 0;
     brotli_globals->ob_handler = NULL;
+	brotli_globals->output_compression_exclude_types = NULL;
 }
 
 typedef struct _php_brotli_stream_data {

--- a/php_brotli.h
+++ b/php_brotli.h
@@ -36,6 +36,7 @@ ZEND_BEGIN_MODULE_GLOBALS(brotli)
   zend_long output_compression;
   zend_long output_compression_default;
   zend_long output_compression_level;
+	char *output_compression_exclude_types;
   char *output_compression_dict;
   zend_bool handler_registered;
   int compression_coding;


### PR DESCRIPTION
## Add MIME Type Exclusions for Transparent Output Compression

### Summary

This patch adds a new INI directive:

```ini
brotli.output_compression_exclude_types
```

The directive allows administrators to exclude selected MIME types from transparent Brotli output compression.

### Examples

```ini
brotli.output_compression_exclude_types="image/*,video/*,audio/*"
```

```ini
brotli.output_compression_exclude_types="application/pdf,application/zip"
```

### Supported Matching

* Exact MIME matches

  * `application/pdf`
  * `application/zip`

* Wildcard family matches

  * `image/*`
  * `video/*`
  * `audio/*`

### Motivation

Many binary formats are already compressed and provide little or no benefit from additional Brotli compression while still consuming CPU resources.

This feature allows administrators to keep transparent output compression enabled while excluding selected content types.

### Changes

* Added `brotli.output_compression_exclude_types` INI directive
* Added MIME matching logic to output handler
* Added documentation and configuration examples to README
* No changes to existing behavior when the directive is unset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `brotli.output_compression_exclude_types` configuration to exclude specific MIME types from transparent Brotli output compression. Accepts comma-separated values with exact MIME matches and `type/*` wildcard family patterns (case-insensitive).

* **Documentation**
  * Expanded configuration docs with detailed syntax, examples, and guidance for the new exclusion option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->