### PR TITLE
Enhance APCu include detection for in-tree builds

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -135,13 +135,20 @@ if test "$PHP_BROTLI" != "no"; then
     PHP_ADD_BUILD_DIR($ext_builddir/brotli/c/enc)
   fi
 
+  dnl APCu
   if test "$PHP_APCU" != "no"; then
     AC_MSG_CHECKING([for APCu includes])
+    if test ! -f "$phpincludedir/ext/apcu/apc_serializer.h" && test -f "$abs_srcdir/ext/apcu/apc_serializer.h"; then
+      phpincludedir="$abs_srcdir"
+    fi
     if test -f "$phpincludedir/ext/apcu/apc_serializer.h"; then
       apc_inc_path="$phpincludedir"
       AC_MSG_RESULT([APCu in $apc_inc_path])
       AC_DEFINE(HAVE_APCU_SUPPORT, 1, [Whether to enable APCu support])
     else
+      if test "$PHP_APCU" != "auto"; then
+        AC_MSG_ERROR([apc_serializer.h header not found])
+      fi
       AC_MSG_RESULT([not found])
     fi
   fi


### PR DESCRIPTION
see https://github.com/kjdev/php-ext-zstd/pull/100

in in-tree compilation it previously always silently falls back to "not found", now it works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of APCu support during configuration, allowing builds to find the required header in more locations.
  * Configuration now continues without APCu support when it is optional, instead of failing outright.
  * When APCu is explicitly requested, setup now provides clearer failure behavior if the support files are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->