### PR TITLE
Fix memory leak when BrotliEncoderCompressStream() fails

### DIFF
--- a/brotli.c
+++ b/brotli.c
@@ -1078,6 +1078,7 @@ static ssize_t php_brotli_compress_write(php_stream *stream,
         } else {
             php_error_docref(NULL, E_WARNING, "brotli: failed to compression");
 #if PHP_VERSION_ID >= 70400
+            efree(output);
             return -1;
 #endif
         }


### PR DESCRIPTION
On `PHP_VERSION_ID >= 70400` we do an early return but don't free `output`, unlike the path we take otherwise.
Detected using an experimental static-dynamic analyser I'm developing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak that could occur when Brotli stream compression encounters a write failure on supported PHP versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->