### PR TITLE
Fix compiler warnings

### DIFF
--- a/brotli.c
+++ b/brotli.c
@@ -1648,7 +1648,6 @@ static ZEND_FUNCTION(brotli_compress_init)
 
 static ZEND_FUNCTION(brotli_compress_add)
 {
-    zval *res;
     php_brotli_context *ctx;
     size_t buffer_size, buffer_used;
     zend_long mode = BROTLI_OPERATION_FLUSH;
@@ -1826,7 +1825,6 @@ static ZEND_FUNCTION(brotli_uncompress_init)
 
 static ZEND_FUNCTION(brotli_uncompress_add)
 {
-    zval *res;
     php_brotli_context *ctx;
     size_t buffer_size;
     zend_long mode = BROTLI_OPERATION_FLUSH;

--- a/brotli.c
+++ b/brotli.c
@@ -25,6 +25,7 @@
 #endif
 
 # pragma GCC diagnostic ignored "-Wpointer-sign"
+# pragma GCC diagnostic ignored "-Wunicode"
 
 ZEND_DECLARE_MODULE_GLOBALS(brotli);
 


### PR DESCRIPTION
LLVM has two things to warn about

```
--- ext/brotli/brotli.lo ---
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/ext/brotli/brotli.c:95:90: warning: \U used with no following hex digits; treating as '\' followed by identifier [-Wunicode]
   95 | ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_brotli_uncompress_init, 0, 0, Brotli\\UnCompress\\Context, MAY_BE_FALSE)
      |                                                                                          ^
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/ext/brotli/brotli.c:105:42: warning: \U used with no following hex digits; treating as '\' followed by identifier [-Wunicode]
  105 |     ZEND_ARG_OBJ_INFO(0, context, Brotli\\UnCompress\\Context, 0)
      |                                          ^
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/ext/brotli/brotli.c:1649:11: warning: unused variable 'res' [-Wunused-variable]
 1649 |     zval *res;
      |           ^~~
/wrkdirs/usr/ports/pave/php85/work-default/php-src-php-8.5.8/ext/brotli/brotli.c:1827:11: warning: unused variable 'res' [-Wunused-variable]
 1827 |     zval *res;
      |           ^~~
4 warnings generated.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compiler compatibility by suppressing an irrelevant GCC warning.
  * Removed unused internal variables without changing externally visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->