### PR TITLE
built-in mime type exclusion list

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,20 +64,20 @@ brotli.output\_compression\_dict               | ""      | PHP\_INI\_ALL
 
 * brotli.output\_compression\_exclude\_types _string_
 
+    Extension contains a built-in list of non-compressible MIME types.
+    The list can be found from phpinfo() output. If something is
+    missing, more MIME types can be added with this ini setting.
+
     Comma-separated list of MIME types that should not be
     compressed by the transparent output handler.
 
     Supports exact MIME type matches and wildcard family matches.
     A wildcard entry must use the `type/*` form.
 
-    Examples:
+    Example (both of these are already in the built-in list):
 
     ```ini
-    brotli.output_compression_exclude_types="image/*,video/*,audio/*"
-    ```
-
-    ```ini
-    brotli.output_compression_exclude_types="application/pdf,application/zip"
+    brotli.output_compression_exclude_types="video/*,application/pdf"
     ```
 
     This is useful for already-compressed binary formats where

--- a/brotli.c
+++ b/brotli.c
@@ -20,6 +20,7 @@
 # pragma GCC visibility push(hidden)
 #endif
 #include "php_brotli.h"
+#include "php_brotli_mimetype_exclude.h"
 #if defined(USE_BROTLI_BUNDLED)
 # pragma GCC visibility pop
 #endif
@@ -381,13 +382,12 @@ static int php_brotli_output_encoding(void)
     return BROTLI_G(compression_coding);
 }
 
-static int php_brotli_output_mimetype_excluded(void)
+static int php_brotli_output_mimetype_excluded(const char *exclude)
 {
 #if defined(COMPILE_DL_BROTLI) && defined(ZTS)
     ZEND_TSRMLS_CACHE_UPDATE();
 #endif
     const char *mimetype = SG(sapi_headers).mimetype;
-    const char *exclude = BROTLI_G(output_compression_exclude_types);
     const char *p, *end;
     size_t mimetype_len;
 
@@ -558,8 +558,12 @@ static int php_brotli_output_handler(void **handler_context,
 {
     php_brotli_context *ctx = *(php_brotli_context **)handler_context;
 
-    if ((output_context->op & PHP_OUTPUT_HANDLER_START) &&
-        php_brotli_output_mimetype_excluded()) {
+    if ((output_context->op & PHP_OUTPUT_HANDLER_START)
+        && (
+            php_brotli_output_mimetype_excluded(BROTLI_MIMETYPE_EXCLUDE)
+            ||
+            php_brotli_output_mimetype_excluded(BROTLI_G(output_compression_exclude_types))
+        )) {
         return FAILURE;
     }
 
@@ -1526,6 +1530,7 @@ ZEND_MINFO_FUNCTION(brotli)
 #if defined(HAVE_APCU_SUPPORT)
     php_info_print_table_row(2, "APCu serializer ABI", APC_SERIALIZER_ABI);
 #endif
+    php_info_print_table_row(2, "Built-in output compression exclusions", BROTLI_MIMETYPE_EXCLUDE);
     php_info_print_table_end();
     DISPLAY_INI_ENTRIES();
 }

--- a/package.xml
+++ b/package.xml
@@ -33,6 +33,7 @@
    <file name="config.m4" role="src" />
    <file name="config.w32" role="src" />
    <file name="php_brotli.h" role="src" />
+   <file name="php_brotli_mimetype_exclude.h" role="src" />
    <file name="brotli/LICENSE" role="doc" />
    <file name="brotli/c/common/constants.c" role="src" />
    <file name="brotli/c/common/constants.h" role="src" />

--- a/php_brotli_mimetype_exclude.h
+++ b/php_brotli_mimetype_exclude.h
@@ -1,0 +1,37 @@
+#ifndef BROTLI_MIMETYPE_EXCLUDE
+
+/**
+ * Image types listed separately, because svg is quite common
+ * and compresses well.
+ *
+ * Less common types have both, x-prefixed and non-prefixed
+ * versions because they are somewhat inconsistent with each
+ * other and perhaps more likely to be misconfigured due to
+ * those inconsistencies.
+ **/
+#define BROTLI_MIMETYPE_EXCLUDE "\
+video/*, \
+audio/*, \
+image/png, \
+image/gif, \
+image/jpeg, \
+image/jxl, \
+image/jp2, \
+image/jpm, \
+image/webp, \
+image/avif, \
+image/x-icon, image/vnd.microsoft.icon, \
+font/woff, application/font-woff, application/x-font-woff, \
+font/woff2, \
+application/pdf, application/x-pdf, \
+application/zip, application/x-zip, application/zip-compressed, application/x-zip-compressed, \
+application/7z-compressed, application/x-7z-compressed, \
+application/vnd.rar, application/x-vnd.rar, \
+application/gzip, application/x-gzip, \
+application/zstd, application/x-zstd, \
+application/br, application/x-br, \
+application/lz4, application/x-lz4, \
+application/bzip2, application/x-bzip2\
+"
+
+#endif

--- a/tests/ob_exclude_001.phpt
+++ b/tests/ob_exclude_001.phpt
@@ -9,7 +9,6 @@ if (false === stristr(PHP_SAPI, 'cgi')) die('skip need sapi/cgi');
 a=b
 --INI--
 brotli.output_compression=1
-brotli.output_compression_exclude_types=application/pdf
 --ENV--
 HTTP_ACCEPT_ENCODING=br
 --FILE--

--- a/tests/ob_exclude_002.phpt
+++ b/tests/ob_exclude_002.phpt
@@ -14,7 +14,7 @@ brotli.output_compression_exclude_types=image/*
 HTTP_ACCEPT_ENCODING=br
 --FILE--
 <?php
-header("Content-Type: image/png");
+header("Content-Type: image/svg+xml");
 echo "hi\n";
 ?>
 --EXPECT--


### PR DESCRIPTION
same thing as [https://github.com/kjdev/php-ext-zstd/pull/104](https://github.com/kjdev/php-ext-zstd/pull/104)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in exclusions for commonly uncompressible media, image, font, archive, compression, and document MIME types.
  * Brotli compression now automatically skips these content types by default while supporting custom exclusions.
  * Module information now displays the built-in exclusion list.
* **Documentation**
  * Clarified exact and wildcard MIME-type matching and how to extend default exclusions.
  * Updated configuration examples to combine multiple MIME types.
* **Tests**
  * Expanded coverage for wildcard image-type exclusions, including SVG content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->