### PR TITLE
phpinfo improvements

### DIFF
--- a/brotli.c
+++ b/brotli.c
@@ -1517,18 +1517,34 @@ ZEND_RSHUTDOWN_FUNCTION(brotli)
 ZEND_MINFO_FUNCTION(brotli)
 {
     php_info_print_table_start();
-    php_info_print_table_row(2, "Brotli support", "enabled");
-    php_info_print_table_row(2, "Extension Version", BROTLI_EXT_VERSION);
+    php_info_print_table_row(2, "Extension version", BROTLI_EXT_VERSION);
+#if defined(USE_BROTLI_BUNDLED)
+    php_info_print_table_row(2, "Brotli library", "bundled");
+#else
+    php_info_print_table_row(2, "Brotli library", "external");
+#endif
     const zval *ver = zend_get_constant_str("BROTLI_VERSION_TEXT",
                                             sizeof("BROTLI_VERSION_TEXT") - 1);
-    php_info_print_table_row(2, "Library Version", Z_STRVAL_P(ver));
+    php_info_print_table_row(2, "Brotli library version", Z_STRVAL_P(ver));
 #if defined(USE_BROTLI_DICTIONARY)
     php_info_print_table_row(2, "Dictionary support", "enabled");
 #else
     php_info_print_table_row(2, "Dictionary support", "disabled");
 #endif
 #if defined(HAVE_APCU_SUPPORT)
-    php_info_print_table_row(2, "APCu serializer ABI", APC_SERIALIZER_ABI);
+    const char *serializer = zend_ini_string("apc.serializer", sizeof("apc.serializer")-1, 0);
+
+    if (serializer == NULL) {
+        php_info_print_table_row(2, "APCu serializer", "APCu extension not loaded");
+    } else if (strcmp(serializer, "brotli") == 0) {
+        php_info_print_table_row(2, "APCu serializer", "brotli active");
+    } else {
+        php_info_print_table_row(2, "APCu serializer", "brotli inactive");
+    }
+
+    php_info_print_table_row(2, "APCu serializer interface version", APC_SERIALIZER_ABI);
+#else
+    php_info_print_table_row(2, "APCu serializer support", "not built");
 #endif
     php_info_print_table_row(2, "Built-in output compression exclusions", BROTLI_MIMETYPE_EXCLUDE);
     php_info_print_table_end();

--- a/tests/info.phpt
+++ b/tests/info.phpt
@@ -4,12 +4,102 @@ Test phpinfo() displays brotli info
 <?php if (!extension_loaded('brotli')) die('skip'); ?>
 --FILE--
 <?php
-phpinfo();
---EXPECTF--
-%a
-brotli
+$ref = new ReflectionExtension('brotli');
+ob_start();
+$ref->info();
+$info = ob_get_contents();
+ob_end_clean();
 
-Brotli support => enabled
-Extension Version => %d.%d.%d
-Library Version => %d.%d.%d
-%a
+// skip uninteresting lines
+$lines = [];
+foreach(explode("\n", $info) as $line) {
+    if ($line && $line !== 'brotli') {
+        $lines[] = $line;
+    }
+}
+
+$verNum = '(([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2}))';
+
+if (count($lines) >= 5) {
+    echo preg_match('/^Extension\sversion\s\=\>\s'.$verNum.'$/', $lines[0]) ? "Ext version OK\n" : "Fail\n";
+
+    $libBrotli = '(bundled|external)';
+    $useDict = '(enabled|disabled)';
+    $hasApcu = null;
+
+    if (file_exists($configH = dirname(__DIR__) . '/config.h')) {
+        $configH = file_get_contents($configH);
+        $libBrotli = preg_match('/define\sUSE_BROTLI_BUNDLED\s1/', $configH) ? 'bundled' : 'external';
+        $useDict = preg_match('/define\sUSE_BROTLI_DICTIONARY\s1/', $configH) ? 'enabled' : 'disabled';
+        $hasApcu = preg_match('/define\sHAVE_APCU_SUPPORT\s1/', $configH) ? true : false;
+    }
+
+    echo preg_match('/^Brotli\slibrary\s\=\>\s'.$libBrotli.'$/', $lines[1]) ? "Bundled/external brotli OK\n" : "Fail\n";
+
+    echo preg_match('/^Brotli\slibrary\sversion\s\=\>\s'.$verNum.'$/', $lines[2]) ? "Brotli version OK\n" : "Fail\n";
+
+    echo preg_match('/^Dictionary\ssupport\s\=\>\s'.$useDict.'$/', $lines[3]) ? "Dictionary OK\n" : "Fail\n";
+
+    if ($hasApcu === null) {
+        echo "Apcu OK\n"; // just assume it is okay
+    } else if ($hasApcu) {
+        if (substr($lines[4], 0, 18) !== 'APCu serializer =>') {
+            echo "Fail\n";
+        } else {
+            $fail = '';
+            $value = substr($lines[4], 19);
+
+            if (!extension_loaded('apcu')) {
+                if ($value !== 'APCu extension not loaded') {
+                    $fail .= 'should be not loaded ';
+                }
+            } else if ($value !== (ini_get('apc.serializer') === 'brotli' ? 'brotli active' : 'brotli inactive')) {
+                $fail .= 'active/inactive mismatch ';
+            }
+
+            if (
+                !isset($lines[5])
+                ||
+                !preg_match('/^APCu\sserializer\sinterface\sversion\s\=\>\s([0-9])/', $lines[5])
+            ) {
+                $fail .= 'ABI ';
+            }
+
+            echo !$fail ? "Apcu OK\n" : ("Fail: " . $fail . "");
+        }
+    } else {
+        echo ($lines[4] == 'APCu serializer support => not built') ? "Apcu OK\n" : "Fail: not built\n";
+    }
+
+    $search = 'Built-in output compression exclusions => ';
+    $mimeIndex = null;
+    // could be 5 or 6 depending on apcu
+    foreach([5, 6] as $index) {
+        if (isset($lines[$index]) && substr($lines[$index], 0, 42) == $search) {
+            $mimeIndex = $index;
+        }
+    }
+    if ($mimeIndex) {
+        $types = explode(', ', substr($lines[$mimeIndex], 42));
+        $invalidTypes = [];
+        foreach($types as $type) {
+            if (!preg_match('/^([a-z]+)\/(([a-z0-9\-\.]+)|\*)$/', $type)) {
+                $invalidTypes[] = $type;
+            }
+        }
+        if ($invalidTypes) {
+            echo "Fail: " . implode(", ", $invalidTypes) . "\n";
+        } else {
+            echo "MIMEs OK\n";
+        }
+    } else {
+        echo "Fail\n";
+    }
+}
+--EXPECTF--
+Ext version OK
+Bundled/external brotli OK
+Brotli version OK
+Dictionary OK
+Apcu OK
+MIMEs OK


### PR DESCRIPTION
- "Brotli support enabled" doesn't provide any information, so just remove it
- show if brotli is bundled or not
- show if brotli is the active serializer for apcu or if apcu isn't loaded
- rename serializer ABI to interface
- if apcu support wasn't built, show that it could have been built

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extension information now displays the Brotli extension version, library source and version, dictionary support, and APCu serializer status.

* **Bug Fixes**
  * Improved diagnostic reporting for bundled or external Brotli libraries and APCu availability, including clearer configuration-specific status details.

* **Tests**
  * Expanded validation of extension details, library configuration, dictionary support, APCu states, MIME exclusions, and consistent diagnostic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->