### PR TITLE
mime exclusion list followup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ brotli.output\_compression\_dict               | ""      | PHP\_INI\_ALL
 
 * brotli.output\_compression\_exclude\_types _string_
 
-    Extension contains a built-in list of non-compressible MIME types.
-    The list can be found from phpinfo() output. If something is
-    missing, more MIME types can be added with this ini setting.
+    The extension contains a built-in list of non-compressible MIME
+    types. The list can be found in the phpinfo() output. If
+    something is missing, more MIME types can be added with this
+    ini setting.
 
     Comma-separated list of MIME types that should not be
     compressed by the transparent output handler.

--- a/package.xml
+++ b/package.xml
@@ -183,6 +183,7 @@
    <file name="tests/ob_exclude_001.phpt" role="test" />
    <file name="tests/ob_exclude_002.phpt" role="test" />
    <file name="tests/ob_exclude_003.phpt" role="test" />
+   <file name="tests/ob_exclude_004.phpt" role="test" />
    <file name="tests/ob_exclude_099.phpt" role="test" />
    <file name="tests/roundtrip.phpt" role="test" />
    <file name="tests/streams_001.phpt" role="test" />

--- a/tests/ob_exclude_004.phpt
+++ b/tests/ob_exclude_004.phpt
@@ -1,5 +1,5 @@
 --TEST--
-built-in output compression exclude list: exact match (no ini set)
+built-in output compression exclude list: wildcard match (no ini set)
 --SKIPIF--
 <?php
 if (!extension_loaded('brotli')) die('skip need ext/brotli');
@@ -13,7 +13,7 @@ brotli.output_compression=1
 HTTP_ACCEPT_ENCODING=br
 --FILE--
 <?php
-header("Content-Type: application/pdf");
+header("Content-Type: audio/mpeg");
 echo "hi\n";
 ?>
 --EXPECT--


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Brotli includes built-in non-compressible MIME types.
  * Documented how to add additional exclusions through the INI setting.

* **Tests**
  * Added coverage for wildcard MIME-type exclusions during CGI output compression.
  * Improved test descriptions for exact-match behavior when no custom exclusions are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->