### PR TITLE
Fix racy tests sharing tests/data.out

### DIFF
--- a/tests/streams_001.phpt
+++ b/tests/streams_001.phpt
@@ -4,7 +4,7 @@ compress.brotli streams basic
 <?php
 include(dirname(__FILE__) . '/data.inc');
 
-$file = dirname(__FILE__) . '/data.out';
+$file = dirname(__FILE__) . '/data_' . basename(__FILE__, ".php") . '.out';
 
 echo "Compression with default level\n";
 

--- a/tests/streams_002.phpt
+++ b/tests/streams_002.phpt
@@ -4,7 +4,7 @@ compress.brotli streams and compatibility
 <?php
 include(dirname(__FILE__) . '/data.inc');
 
-$file = dirname(__FILE__) . '/data.out';
+$file = dirname(__FILE__) . '/data_' . basename(__FILE__, ".php") . '.out';
 
 echo "Stream compression + brotli_uncompress\n";
 

--- a/tests/streams_004.phpt
+++ b/tests/streams_004.phpt
@@ -4,7 +4,7 @@ compress.brotli streams with file functions
 <?php
 include(dirname(__FILE__) . '/data.inc');
 
-$file = dirname(__FILE__) . '/data.out';
+$file = dirname(__FILE__) . '/data_' . basename(__FILE__, ".php") . '.out';
 
 echo "Compression\n";
 


### PR DESCRIPTION
streams_001, streams_002 and streams_004 all write, stat and unlink the very same file tests/data.out. Since php-src https://github.com/php/php-src/commit/1d2ea5ce22c ("Run tests in parallel by default", [GH-22939](https://github.com/php/php-src/pull/22939), first released in php-8.6.0beta1) run-tests.php spawns min(nproc, 10) workers by default, so these three tests race each other and fail intermittently - filesize()/file_get_contents() hit a path a sibling test has just unlinked.

Give each test its own scratch file, the way tests/dictionary_streams.phpt already does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated stream test output files to use unique, test-specific filenames.
  * Prevented multiple tests from sharing and potentially overwriting the same output file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->