### PR TITLE
upgrade: version to 0.21.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,10 +10,10 @@
   <email>kjdev@php.net</email>
   <active>yes</active>
  </lead>
- <date>2026-07-02</date>
+ <date>2026-08-13</date>
  <version>
-  <release>0.20.0</release>
-  <api>0.20.0</api>
+  <release>0.21.0</release>
+  <api>0.21.0</api>
  </version>
  <stability>
   <release>stable</release>
@@ -21,9 +21,11 @@
  </stability>
  <license>MIT</license>
  <notes>
-- add: MIME type exclusions for transparent output compression (brotli.output_compression_exclude_types)
-- add: --enable-apcu configure option to explicitly control APCu serializer support
-- fix: enhance APCu include detection for in-tree builds
+- add: built-in MIME type exclusion list for transparent output compression
+- add: negation tokens (!) in brotli.output_compression_exclude_types
+- add: phpinfo() improvements (bundled/external library, APCu serializer status)
+- fix: memory leak when BrotliEncoderCompressStream() fails on PHP 7.4+
+- fix: compiler warnings
  </notes>
  <contents>
   <dir name="/">
@@ -184,6 +186,10 @@
    <file name="tests/ob_exclude_002.phpt" role="test" />
    <file name="tests/ob_exclude_003.phpt" role="test" />
    <file name="tests/ob_exclude_004.phpt" role="test" />
+   <file name="tests/ob_exclude_005.phpt" role="test" />
+   <file name="tests/ob_exclude_006.phpt" role="test" />
+   <file name="tests/ob_exclude_007.phpt" role="test" />
+   <file name="tests/ob_exclude_008.phpt" role="test" />
    <file name="tests/ob_exclude_099.phpt" role="test" />
    <file name="tests/roundtrip.phpt" role="test" />
    <file name="tests/streams_001.phpt" role="test" />

--- a/php_brotli.h
+++ b/php_brotli.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#define BROTLI_EXT_VERSION "0.20.0"
+#define BROTLI_EXT_VERSION "0.21.0"
 #define BROTLI_NS "Brotli"
 
 /* brotli */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package to version 0.21.0, dated August 13, 2026.

* **Bug Fixes**
  * Fixed a memory leak affecting Brotli stream compression.
  * Addressed compiler warnings.

* **Improvements**
  * Improved phpinfo output.
  * Added support documentation for MIME exclusion lists and negation tokens.

* **Testing**
  * Expanded coverage for output-buffer exclusion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->